### PR TITLE
Correcting issue regarding splitted error responses

### DIFF
--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -15,7 +15,7 @@
 %% functions. This is used to continue where we left off the next time
 %% the user calls parse/2.
 -type continuation_data() :: any().
--type parser_state() :: status_continue | bulk_continue | multibulk_continue.
+-type parser_state() :: status_continue | bulk_continue | multibulk_continue | error_continue.
 
 %% Internal types
 -ifdef(namespaced_types).

--- a/src/eredis_parser.erl
+++ b/src/eredis_parser.erl
@@ -74,7 +74,7 @@ parse(#pstate{state = undefined} = State, NewData) ->
 
         %% Error
         <<$-, Data/binary>> ->
-            return_error(parse_simple(Data), State, status_continue);
+            return_error(parse_simple(Data), State, error_continue);
 
         %% Integer reply
         <<$:, Data/binary>> ->
@@ -106,7 +106,11 @@ parse(#pstate{state = multibulk_continue,
 
 parse(#pstate{state = status_continue,
              continuation_data = ContinuationData} = State, NewData) ->
-    return_result(parse_simple(ContinuationData, NewData), State, status_continue).
+    return_result(parse_simple(ContinuationData, NewData), State, status_continue);
+
+parse(#pstate{state = error_continue,
+             continuation_data = ContinuationData} = State, NewData) ->
+    return_error(parse_simple(ContinuationData, NewData), State, error_continue).
 
 %%
 %% MULTIBULK

--- a/test/eredis_parser_tests.erl
+++ b/test/eredis_parser_tests.erl
@@ -308,6 +308,19 @@ error_test() ->
     ?assertEqual({error, <<"ERR wrong number of arguments for 'get' command">>, init()},
                  parse(init(), B)).
 
+error_chunked_test() ->
+    B1 = <<"-ERR">>,
+    B2 = <<" wrong number of arguments for 'get' command\r\n">>,
+    State1 = init(),
+
+    {continue, State2} = parse(State1, B1),
+    Buffer = buffer_create(<<"ERR">>),
+    ?assertEqual(#pstate{state = error_continue, continuation_data = {incomplete_simple, Buffer}},
+                 State2),
+
+    ?assertEqual({error, <<"ERR wrong number of arguments for 'get' command">>, init()},
+                 parse(State2, B2)).
+
 integer_test() ->
     B = <<":2\r\n">>,
     ?assertEqual({ok, <<"2">>, init()}, parse(init(), B)).


### PR DESCRIPTION
When a RESP Errors message is read from the socket in multiple chunks it will result in an OK message, not an error message. This due to that the parser state is wrongly set after reading the first part. This corrects the issue, see added test.