### PR TITLE
Use proplists for client options

### DIFF
--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -2,7 +2,9 @@
 
 -type reconnect_sleep() :: no_reconnect | integer().
 
--type option() :: {database, string()} | {password, string()} | {reconnect_sleep, reconnect_sleep()}.
+-type option() :: {database, string()} | {password, string()} | {reconnect_sleep, reconnect_sleep()} |
+                  {connect_timeout, integer()} | {socket_options, list()}.
+
 -type options() :: [option()].
 
 -type return_value() :: undefined | binary() | [binary() | nonempty_list()].

--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -2,8 +2,8 @@
 
 -type reconnect_sleep() :: no_reconnect | integer().
 
--type option() :: {host, string()} | {port, integer()} | {database, string()} | {password, string()} | {reconnect_sleep, reconnect_sleep()}.
--type server_args() :: [option()].
+-type option() :: {database, string()} | {password, string()} | {reconnect_sleep, reconnect_sleep()}.
+-type options() :: [option()].
 
 -type return_value() :: undefined | binary() | [binary() | nonempty_list()].
 

--- a/rebar.config
+++ b/rebar.config
@@ -24,6 +24,11 @@
 {cover_excl_mods, [ basho_bench_driver_erldis
                   , basho_bench_driver_eredis]}.
 
+{dialyzer, [{warnings, [ error_handling
+                    %% , unmatched_returns
+                    %% , race_conditions
+                       ]}]}.
+
 {xref_checks, [ undefined_function_calls
               , locals_not_used
               , deprecated_function_calls

--- a/src/eredis_sub.erl
+++ b/src/eredis_sub.erl
@@ -37,7 +37,7 @@ start_link(Host, Port, Password, ReconnectSleep,
                                  MaxQueueSize, QueueBehaviour).
 
 %% @doc: Callback for starting from poolboy
--spec start_link(server_args()) -> {ok, Pid::pid()} | {error, Reason::term()}.
+-spec start_link(options()) -> {ok, Pid::pid()} | {error, Reason::term()}.
 start_link(Args) ->
     Host           = proplists:get_value(host, Args, "127.0.0.1"),
     Port           = proplists:get_value(port, Args, 6379),


### PR DESCRIPTION
This enables adding a larger amount of configs needed for the TLS support.