### PR TITLE
Handle expired client certificate errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Non-blocking Redis client with focus on performance and robustness.
 
-Improvements compared to `wooga/eredis`:
+Improvements and changes compared to `wooga/eredis`:
 
 * Support of TLS introduced in Redis 6
 * Changed API: `start_link` takes a proplist with options
@@ -11,6 +11,7 @@ Improvements compared to `wooga/eredis`:
 * Elvis code formatting
 * Improved test coverage
 * Containerized testing
+* Default reconnection sleep changed from 100ms to 1s
 
 Supported Redis features:
 
@@ -149,7 +150,7 @@ the following arguments:
 * Options, a proplist that can contain following, default: []
   * `database`: integer or 0 for default database, default: 0
   * `password`: string or empty string for no password, default: "" i.e. no password
-  * `reconnect_sleep`: integer of milliseconds to sleep between reconnect attempts, default: 100
+  * `reconnect_sleep`: integer of milliseconds to sleep between reconnect attempts, default: 1000
   * `connect_timeout`: timeout value in milliseconds to use in the connect, default: 5000
   * `socket_options`: proplist of options used when connecting the socket, default is `?SOCKET_OPTS`
   * `tls`: enabling TLS and a proplist of options used when establishing the TLS connection, default is off

--- a/priv/genenerate-test-certs.sh
+++ b/priv/genenerate-test-certs.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-mkdir -p configs/tls
-mkdir -p configs/tls_expired_client_certs
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/configs"
+cd ${BASEDIR}
 
-cd configs
+mkdir -p tls
+mkdir -p tls_expired_client_certs
 
 # CA
 openssl genrsa -out tls/ca.key 4096
@@ -65,3 +66,26 @@ openssl req \
 # Make sure files are readable from the redis container
 chmod 664 tls/*
 chmod 664 tls_expired_client_certs/*
+
+# Generate soon expired client cert
+DIR=tls_soon_expired_client_certs
+mkdir -p ${DIR}
+cp tls/ca.crt ${DIR}/
+openssl genrsa -out ${DIR}/client.key 2048
+
+# -60*24 + 1 minute ago
+openssl req \
+    -new -sha256 \
+    -key ${DIR}/client.key \
+    -subj '/O=Eredis Test/CN=Client' | \
+    faketime -f '-1439m' \
+        openssl x509 \
+             -req -sha256 \
+             -CA tls/ca.crt \
+             -CAkey tls/ca.key \
+             -CAserial tls/ca.txt \
+             -CAcreateserial \
+             -days 1 \
+             -out ${DIR}/client.crt
+
+chmod 664 ${DIR}/*

--- a/priv/update-client-cert.sh
+++ b/priv/update-client-cert.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/configs"
+
+DIRNAME=${1:-tls_soon_expired_client_certs}
+
+# Regenerate soon expired client cert
+DIR=${BASEDIR}/${DIRNAME}/
+
+mkdir -p ${DIR}
+openssl genrsa -out ${DIR}/client.key 2048
+
+cp ${BASEDIR}/tls/ca.crt ${DIR}/
+
+# -60*24 + 1 minute ago, i.e. expires in 1 minute
+openssl req \
+    -new -sha256 \
+    -key ${DIR}/client.key \
+    -subj '/O=Eredis Test/CN=Client' | \
+    faketime -f '-1439m' \
+        openssl x509 \
+             -req -sha256 \
+             -CA       ${BASEDIR}/tls/ca.crt \
+             -CAkey    ${BASEDIR}/tls/ca.key \
+             -CAserial ${BASEDIR}/tls/ca.txt \
+             -CAcreateserial \
+             -days 1 \
+             -out ${DIR}/client.crt
+
+chmod 664 ${DIR}/*
+

--- a/test/eredis_SUITE.erl
+++ b/test/eredis_SUITE.erl
@@ -1,0 +1,78 @@
+-module(eredis_SUITE).
+
+%% Test framework
+-export([ init_per_suite/1
+        , end_per_suite/1
+        , all/0
+        , suite/0
+        ]).
+
+%% Test cases
+-export([ t_expiring_certs/1
+        ]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-define(TLS_PORT, 6380).
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+all() -> [F || {F, _A} <- module_info(exports),
+               case atom_to_list(F) of
+                   "t_" ++ _ -> true;
+                   _         -> false
+               end].
+
+suite() -> [{timetrap, {minutes, 10}}].
+
+%% Tests
+
+t_expiring_certs(Config) when is_list(Config) ->
+    Dir = filename:join([code:priv_dir(eredis), "configs", "tls_soon_expired_client_certs"]),
+    Options = [{tls, [{cacertfile, filename:join([Dir, "ca.crt"])},
+                      {certfile,   filename:join([Dir, "client.crt"])},
+                      {keyfile,    filename:join([Dir, "client.key"])},
+                      {verify,     verify_peer},
+                      {server_name_indication, "Server"}]}],
+
+    %%observer:start(),
+
+    ct:pal("Connect a client with a certificate that expires in 1 minute"),
+    Res = eredis:start_link("127.0.0.1", ?TLS_PORT, Options),
+    ?assertMatch({ok, _}, Res),
+    {ok, C} = Res,
+
+    ?assertEqual({ok, undefined}, eredis:q(C, ["GET", foo])),
+    ?assertEqual({ok, <<"OK">>}, eredis:q(C, ["SET", foo, bar1])),
+    ?assertEqual({ok, <<"bar1">>}, eredis:q(C, ["GET", foo])),
+
+    ct:pal(user, "Sleep 1 minute [1 of 2]"),
+    timer:sleep(1 * 60 * 1000),
+
+    %% Client works even when certificate has expired
+    ?assertEqual({ok, <<"OK">>}, eredis:q(C, ["SET", foo, bar2])),
+    ?assertEqual({ok, <<"bar2">>}, eredis:q(C, ["GET", foo])),
+
+    ct:pal(user, "Sleep 1 minute [2 of 2]"),
+    timer:sleep(1 * 60 * 1000),
+
+    ?assertEqual({ok, <<"OK">>}, eredis:q(C, ["SET", foo, bar3])),
+    ?assertEqual({ok, <<"bar3">>}, eredis:q(C, ["GET", foo])),
+    ct:pal(user, "Stopping client"),
+    ?assertMatch(ok, eredis:stop(C)),
+
+    %% Reconnect, will give ok during connect+handshake
+    %% but trigger a ssl_error that makes the client try reconnect
+    ct:pal("Reconnect, now with expired certificate..."),
+    Res2 = eredis:start_link("127.0.0.1", ?TLS_PORT, Options),
+    ?assertMatch({ok, _}, Res2),
+    {ok, C2} = Res2,
+
+    ?assertEqual({error, no_connection}, eredis:q(C2, ["SET", foo, bar4])),
+    ?assertMatch(ok, eredis:stop(C2)),
+    ok.

--- a/test/eredis_tests.erl
+++ b/test/eredis_tests.erl
@@ -230,7 +230,7 @@ tcp_closed_test() ->
     C = c(),
     ?assertMatch({ok, _}, eredis:q(C, ["DEL", foo], 5000)),
     tcp_closed_rig(C),
-    timer:sleep(300), %% Wait for reconnection (100ms)
+    timer:sleep(1300), %% Wait for reconnection (1000ms)
     ?assertMatch({ok, _}, eredis:q(C, ["DEL", foo], 5000)).
 
 tcp_closed_no_reconnect_test() ->

--- a/test/eredis_tls_tests.erl
+++ b/test/eredis_tls_tests.erl
@@ -27,7 +27,7 @@ tls_closed_test() ->
     C = c_tls(),
     ?assertMatch({ok, _}, eredis:q(C, ["DEL", foo], 5000)),
     tls_closed_rig(C),
-    timer:sleep(300), %% Wait for reconnection (100ms)
+    timer:sleep(1300), %% Wait for reconnection (1000ms)
     ?assertMatch({ok, _}, eredis:q(C, ["DEL", foo], 5000)),
     ?assertMatch(ok, eredis:stop(C)).
 


### PR DESCRIPTION
Alert and perform reconnections until cert has been updated.
Change reconnection to sleep before first re-attempt.

Also adding a ct test for cert failures