### PR TITLE
Add test for changed certerror behaviour in TLS1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: erlang
 
 sudo: required
 
+# Default is 16.04 (xenial) but 18.04 is needed to get TLS 1.3 working
+dist: bionic
+
 services:
   - docker
 
@@ -15,13 +18,11 @@ notifications:
   email: false
 
 otp_release:
+  - 23.0
+  - 22.3
   - 22.1
-  # - 21.0.1
-  # - 20.3
-  # - 19.3
-  # - 18.3
-  # - 17.5
-  # - R16B03-1
+  - 21.2
+  - 20.3.8
 
 script:
   - make elvis

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -169,7 +169,7 @@ handle_info({tcp_error, _Socket, _Reason}, State) ->
     {noreply, State};
 
 %% SSL socket errors
-%% Called after a connect when the client certificate has expired
+%% TLS 1.3: Called after a connect when the client certificate has expired
 handle_info({ssl_error, _Socket, Reason}, State) ->
     maybe_reconnect(Reason, State);
 
@@ -375,7 +375,7 @@ connect(State) ->
                             {error, {authentication_error, Reason}}
                     end;
                 {error, Reason} ->
-                    {error, {failed_to_upgrade_to_tls, Reason}}
+                    {error, {failed_to_upgrade_to_tls, Reason}} %% Used in TLS v1.2
             end;
         {error, Reason} ->
             {error, {connection_error, Reason}}


### PR DESCRIPTION
- Update travis (Erlang versions and Ubuntu base to get TLS1.3)
- Close client in tests to avoid interference