### PR TITLE
Add some test scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,14 @@ install:
   - sudo apt-get install -qq --no-install-recommends faketime
   - sudo docker info
   - git clone https://github.com/erlang/rebar3.git && cd rebar3 && git checkout 3.13.1 && ./bootstrap && sudo mv rebar3 /usr/local/bin/ && cd ..
-  - git clone https://github.com/inaka/elvis.git && cd elvis && rebar3 escriptize && sudo cp _build/default/bin/elvis /usr/bin && cd ..
+  - git clone https://github.com/inaka/elvis.git && cd elvis && rebar3 escriptize && sudo cp _build/default/bin/elvis /usr/local/bin/ && cd ..
+
+before_script:
+  # Add an IPv6 config - see the corresponding Travis issue
+  # https://github.com/travis-ci/travis-ci/issues/8361
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
+    fi
 
 script:
   - make elvis

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Improvements and changes compared to `wooga/eredis`:
 * Improved test coverage
 * Containerized testing
 * Default reconnection sleep changed from 100ms to 1s
+* Unknown Erlang messages wont stop the client.
 
 Supported Redis features:
 

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -221,8 +221,8 @@ handle_info(initiate_connection, #state{socket = undefined} = State) ->
             maybe_reconnect(Reason, State)
     end;
 
-handle_info(Info, State) ->
-    {stop, {unhandled_message, Info}, State}.
+handle_info(_Info, State) ->
+    {noreply, State}.
 
 terminate(_Reason, State) ->
     close_socket(State, State#state.socket).

--- a/test/eredis_test_utils.erl
+++ b/test/eredis_test_utils.erl
@@ -1,8 +1,81 @@
 -module(eredis_test_utils).
 
--export([ get_tcp_ports/0 ]).
+%% API.
+-export([ get_tcp_ports/0
+        , get_tcp_ports/1
+        , start_server/1
+        , stop_server/1
+        , await_connect/1
+        , await_connect/2
+        ]).
 
-% Get number of available TCP ports (includes TLS)
+%% Internal
+-export([ start_server/2 ]).
+
+%% Get available TCP ports (includes TLS)
+-spec get_tcp_ports() -> [erlang:port()].
 get_tcp_ports() ->
     [Port || Port <- erlang:ports(),
              {name, "tcp_inet"} =:= erlang:port_info(Port, name)].
+
+%% Get available TCP ports (includes TLS) handled by pid
+-spec get_tcp_ports(Pid :: pid()) -> [erlang:port()].
+get_tcp_ports(Pid) ->
+    [Port || Port <- get_tcp_ports(),
+             {connected, Pid} =:= erlang:port_info(Port, connected)].
+
+%% Start a server port and run Fun when a client connect.
+-spec start_server(Fun :: fun((ClientSocket::inet:socket()) -> ok)) ->
+          {ok, inet:port_number()}.
+start_server(Fun) ->
+    Pid = spawn_link(?MODULE, start_server, [self(), Fun]),
+    Port = receive_from(Pid, 5000),
+    {ok, Pid, Port}.
+
+%% Stop server and close client socket aswell if needed.
+-spec stop_server(Pid :: pid()) -> ok.
+stop_server(Pid) ->
+    Pid ! shutdown.
+
+%% Wait for a client to connect to server
+-spec await_connect(Pid :: pid()) -> ok.
+await_connect(Pid) ->
+    await_connect(Pid, 5000).
+
+-spec await_connect(Pid :: pid(), Timeout :: integer()) -> ok.
+await_connect(Pid, Timeout) ->
+    receive {Pid, connect} ->
+            ok
+    after Timeout ->
+            error(timeout)
+    end.
+
+%% Internal
+
+start_server(Parent, Fun) ->
+    {ok, ListenSocket} = gen_tcp:listen(0, [binary, {active, false}]),
+    {ok, {_, Port}} = inet:sockname(ListenSocket),
+    Parent ! {self(), Port},
+    {ok, ClientSocket} = gen_tcp:accept(ListenSocket, 5000),
+    Parent ! {self(), connect},
+    Fun(ClientSocket),
+    loop_server(ListenSocket, ClientSocket).
+
+loop_server(ListenSocket, ClientSocket) ->
+    receive
+        shutdown ->
+            gen_tcp:close(ClientSocket),
+            gen_tcp:close(ListenSocket),
+            ok;
+        _ ->
+            loop_server(ListenSocket, ClientSocket)
+    end.
+
+receive_from(Pid, Timeout) ->
+    receive
+        {Pid, Msg} ->
+            Msg
+    after
+        Timeout ->
+            error(timeout)
+    end.


### PR DESCRIPTION
- Connect using IPv6
- Reconnect at send errors
- Use of start_link/1 (like poolboy)
- Test of socket close during connect (AUTH/DATABASE)
- Test of messages

Improved coverage:
eredis               82%  -> 100%
eredis_client     80%  ->  86%

Total	          85%  ->  88%