### PR TITLE
Add Redis compability test runs

### DIFF
--- a/.github/workflows/redis_compability.yml
+++ b/.github/workflows/redis_compability.yml
@@ -1,0 +1,56 @@
+name: Redis compability testing
+on:
+  push:
+  pull_request:
+    branches:
+      # Branches from forks have the form 'user:branch-name' so we only run
+      # this job on pull_request events for branches that look like fork
+      # branches. Without this we would end up running this job twice for non
+      # forked PRs, once for the push and then once for opening the PR.
+      - '**:**'
+
+jobs:
+  redis-comp:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - redis-version: 6.2-rc1
+            test-target: ct
+          - redis-version: 6.0.9
+            test-target: ct
+          - redis-version: 5.0.10
+            test-target: ct-tcp
+          - redis-version: 4.0.14
+            test-target: ct-tcp
+          - redis-version: 3.2.7
+            test-target: ct-tcp
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache Hex packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/rebar3/hex/hexpm/packages
+          key: ${{ runner.os }}-hex-${{ hashFiles('**/rebar.lock') }}
+          restore-keys: ${{ runner.os }}-hex-
+
+      - name: Install Erlang/OTP
+        run: |
+          DEB_NAME="esl-erlang_23.1-1~ubuntu~focal_amd64.deb"
+          curl -f https://packages.erlang-solutions.com/erlang/debian/pool/$DEB_NAME -o $DEB_NAME
+          sudo dpkg --install $DEB_NAME
+
+      - name: Install faketime
+        run: |
+          sudo apt update
+          sudo apt install -yy --no-install-recommends faketime
+
+      - name: Build
+        run: make compile
+
+      - name: Test
+        run: |
+          REDIS_VERSION=${{ matrix.redis-version }} make ${{ matrix.test-target }}

--- a/test/eredis_tcp_SUITE.erl
+++ b/test/eredis_tcp_SUITE.erl
@@ -262,7 +262,8 @@ t_faulty_logical_database(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
     Res = eredis:start_link("127.0.0.1", ?PORT, [{database, 99999999},
                                                  {reconnect_sleep, no_reconnect}]),
-    ?assertMatch({error, {select_error, {unexpected_response, <<"-ERR DB", _/binary>>}}}, Res),
+    %% Note: The error message content has changed from Redis 3 to Redis 4
+    ?assertMatch({error, {select_error, {unexpected_response, <<"-ERR", _/binary>>}}}, Res),
     IsDead = receive {'EXIT', _, _} -> died
              after 1000 -> still_alive end,
     process_flag(trap_exit, false),
@@ -272,7 +273,8 @@ t_authentication_error(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
     Res = eredis:start_link("127.0.0.1", ?PORT, [{password, "password"},
                                                  {reconnect_sleep, no_reconnect}]),
-    ?assertMatch({error, {authentication_error, {unexpected_response, <<"-ERR AUTH", _/binary>>}}}, Res),
+    %% Note: The error message content has changed from Redis 5 to Redis 6
+    ?assertMatch({error, {authentication_error, {unexpected_response, <<"-ERR", _/binary>>}}}, Res),
     IsDead = receive {'EXIT', _, _} -> died
              after 1000 -> still_alive end,
     process_flag(trap_exit, false),


### PR DESCRIPTION
Run tests towards Redis version:
6.2-rc1, 6.0.9, 5.0.10, 4.0.14 and 3.2.7