### PR TITLE
Add link to benchmark testing graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,20 @@ appropriately, even when reconnecting after a timeout.
 
 ## Benchmarking
 
-Using [basho_bench](https://github.com/basho/basho_bench/) you may
+Using [lasp-bench](https://github.com/lasp-lang/lasp-bench/) you may
 benchmark Eredis on your own hardware using the provided config and
 driver. See `priv/basho_bench_driver_eredis.config` and
 `src/basho_bench_driver_eredis.erl`.
+
+Testcase summary from our daily runs:
+
+* [eredis](https://bjosv.github.io/eredis-benchmark/results/latest/eredis/summary.png)
+* [eredis_pipeline](https://bjosv.github.io/eredis-benchmark/results/latest/eredis_pipeline/summary.png)
+
+The [eredis-benchmark](https://github.com/bjosv/eredis-benchmark) repo runs
+a daily job that produces above graphs. It also contains the script
+`run-tests.sh` that might help you with the needed steps when setting up the
+benchmark testing on your own.
 
 ## Queueing
 

--- a/priv/basho_bench_eredis.config
+++ b/priv/basho_bench_eredis.config
@@ -7,7 +7,7 @@
 
 {driver, basho_bench_driver_eredis}.
 
-{code_paths, ["../eredis/ebin"]}.
+{code_paths, ["_build/default/lib/eredis/ebin"]}.
 
 {operations, [{get,1}, {put,4}]}.
 

--- a/priv/basho_bench_eredis_pipeline.config
+++ b/priv/basho_bench_eredis_pipeline.config
@@ -7,7 +7,7 @@
 
 {driver, basho_bench_driver_eredis}.
 
-{code_paths, ["../eredis/ebin"]}.
+{code_paths, ["_build/default/lib/eredis/ebin"]}.
 
 {operations, [{pipeline_get,100}, {pipeline_put,1}]}.
 

--- a/src/basho_bench_driver_eredis.erl
+++ b/src/basho_bench_driver_eredis.erl
@@ -23,7 +23,7 @@ new(_Id) ->
 run(get, KeyGen, _ValueGen, Client) ->
     Start = KeyGen(),
     %%case eredis:q(["MGET" | lists:seq(Start, Start + 500)]) of
-    case catch(eredis:q(Client, ["GET", Start], 100)) of
+    case catch(eredis:q(Client, ["GET", Start], 200)) of
         {ok, _Value} ->
             {ok, Client};
         {error, Reason} ->
@@ -51,7 +51,7 @@ run(pipeline_get, KeyGen, _ValueGen, Client) ->
     end;
 
 run(put, KeyGen, ValueGen, Client) ->
-    case catch(eredis:q(Client, ["SET", KeyGen(), ValueGen()], 100)) of
+    case catch(eredis:q(Client, ["SET", KeyGen(), ValueGen()], 200)) of
         {ok, <<"OK">>} ->
             {ok, Client};
         {error, Reason} ->


### PR DESCRIPTION
- Suggest using the working basho_bench fork `lasp-bench` for benchmarking 
- Update the benchmark configs with new rebar3 paths 
- Set a more forgiving timeout in eredis benchmark testcase