### PR TITLE
Detect OTP >= 21 even if rebar is not used

### DIFF
--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -27,10 +27,14 @@
 -type parser_state() :: status_continue | bulk_continue | multibulk_continue | error_continue.
 
 %% Internal types
--ifdef(namespaced_types).
+-ifdef(OTP_RELEASE). % OTP >= 21
+-type eredis_queue() :: queue:queue().
+-else.
+-ifdef(namespaced_types). % Macro defined in rebar.conf if OTP >= 17
 -type eredis_queue() :: queue:queue().
 -else.
 -type eredis_queue() :: queue().
+-endif.
 -endif.
 
 %% Internal parser state. Is returned from parse/2 and must be

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Eredis.Mixfile do
   def project do
     [
       app: :eredis,
-      version: "1.2.0",
-      elixir: "~> 1.5.1",
+      version: "1.3.0-nordix",
+      elixir: ">= 1.5.1",
       start_permanent: Mix.env == :prod,
       deps: deps()
     ]


### PR DESCRIPTION
Fix compilation without Rebar.

Also update mix.exs to allow later versions of Elixir.