### PR TITLE
Fix intermittent Common Test case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all compile clean test ut ct-tcp ct-tls edoc xref dialyzer elvis cover coverview
 
-REDIS_VERSION ?= 6.0.4
+REDIS_VERSION ?= 6.0.10
 
 all: compile xref dialyzer elvis
 


### PR DESCRIPTION
This corrects the intermittent fault in `t_tcp_closed`.
We now make sure that the order of sending commands and simulating
a disconnect should be correct even on loaded CI machines.

This also corrects the same (not yet seen?) issue in testcase
`t_tcp_closed_no_reconnect`.