### PR TITLE
Documentation generation for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ Emakefile
 .DS_Store
 _build
 erl_crash.dump
-/doc/README.md
-/doc/erlang.png
-/doc/edoc-info
-/doc/stylesheet.css
+doc/
+deps/
+mix.lock

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,17 @@ Emakefile
 .DS_Store
 _build
 erl_crash.dump
-doc/
+
+# edoc and edown
+doc/README.md
+doc/edoc-info
+doc/erlang.png
+doc/stylesheet.css
+
+# mix
+doc/*.html
+doc/*.epub
+doc/.build
+doc/dist
 deps/
 mix.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # CHANGELOG
 
+## v1.3.2
+
+February 2021.
+
+* Official release
+
 ## v1.3.1-nordix
 
 February 2021.
 
 * Fix build problems with Mix and other non-Rebar tools
-* Mix file to publish in Hex.pm
-* Nordix fork turns to be the official distributed version on Hex.pm
 
 ## v1.3.0-nordix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 February 2021.
 
 * Fix build problems with Mix and other non-Rebar tools
+* Mix file to publish in Hex.pm
+* Nordix fork turns to be the official distributed version on Hex.pm
 
 ## v1.3.0-nordix
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Supported Redis features:
  * Authentication & multiple DBs
  * Pubsub
 
-Generedated API documentation: [doc/eredis.md](doc/eredis.md)
+Generated API documentation: [doc/eredis.md](doc/eredis.md)
+
+Published documentation can also be found on [hexdocs](https://hexdocs.pm/eredis/).
 
 ## Setup
 

--- a/doc/eredis.md
+++ b/doc/eredis.md
@@ -12,72 +12,86 @@
 
 
 
-### <a name="type-client">client()</a> ###
+<a name="type-client"></a>
+### client() ###
 
 
 <pre><code>
 client() = pid() | atom() | {atom(), atom()} | {global, term()} | {via, atom(), term()}
-</code></pre>
+</code>
+</pre>
 
 
 
 
-### <a name="type-host">host()</a> ###
+<a name="type-host"></a>
+### host() ###
 
 
 <pre><code>
 host() = string() | {local, string()}
-</code></pre>
+</code>
+</pre>
 
 
 
 
-### <a name="type-option">option()</a> ###
+<a name="type-option"></a>
+### option() ###
 
 
 <pre><code>
 option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer() | string()} | {password, string()} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]}
-</code></pre>
+</code>
+</pre>
 
 
 
 
-### <a name="type-options">options()</a> ###
+<a name="type-options"></a>
+### options() ###
 
 
 <pre><code>
 options() = [<a href="#type-option">option()</a>]
-</code></pre>
+</code>
+</pre>
 
 
 
 
-### <a name="type-pipeline">pipeline()</a> ###
+<a name="type-pipeline"></a>
+### pipeline() ###
 
 
 <pre><code>
 pipeline() = [iolist()]
-</code></pre>
+</code>
+</pre>
 
 
 
 
-### <a name="type-reconnect_sleep">reconnect_sleep()</a> ###
+<a name="type-reconnect_sleep"></a>
+### reconnect_sleep() ###
 
 
 <pre><code>
 reconnect_sleep() = no_reconnect | integer()
-</code></pre>
+</code>
+</pre>
 
 
 
 
-### <a name="type-return_value">return_value()</a> ###
+<a name="type-return_value"></a>
+### return_value() ###
 
 
 <pre><code>
 return_value() = undefined | binary() | [binary() | nonempty_list()]
-</code></pre>
+</code>
+</pre>
 
 <a name="index"></a>
 
@@ -88,7 +102,8 @@ return_value() = undefined | binary() | [binary() | nonempty_list()]
 response (with either error or success).</td></tr><tr><td valign="top"><a href="#q_async-3">q_async/3</a></td><td>Executes the command, and sends a message to <code>Pid</code> with the response
 (with either or success).</td></tr><tr><td valign="top"><a href="#q_noreply-2">q_noreply/2</a></td><td>Executes the command but does not wait for a response and ignores any
 errors.</td></tr><tr><td valign="top"><a href="#qp-2">qp/2</a></td><td> Executes the given pipeline (list of commands) in the
-specified connection.</td></tr><tr><td valign="top"><a href="#qp-3">qp/3</a></td><td>Like qp/2 with a custom timeout.</td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td>Connect with default options.</td></tr><tr><td valign="top"><a href="#start_link-1">start_link/1</a></td><td>Connect with the given options.</td></tr><tr><td valign="top"><a href="#start_link-2">start_link/2</a></td><td>Connect to the given host and port.</td></tr><tr><td valign="top"><a href="#start_link-3">start_link/3</a></td><td>(<em>Deprecated</em>.) </td></tr><tr><td valign="top"><a href="#start_link-4">start_link/4</a></td><td>(<em>Deprecated</em>.) </td></tr><tr><td valign="top"><a href="#start_link-5">start_link/5</a></td><td>(<em>Deprecated</em>.) </td></tr><tr><td valign="top"><a href="#start_link-6">start_link/6</a></td><td>(<em>Deprecated</em>.) </td></tr><tr><td valign="top"><a href="#start_link-7">start_link/7</a></td><td>(<em>Deprecated</em>.) </td></tr><tr><td valign="top"><a href="#stop-1">stop/1</a></td><td>Closes the connection and stops the client.</td></tr></table>
+specified connection.</td></tr><tr><td valign="top"><a href="#qp-3">qp/3</a></td><td>Like qp/2 with a custom timeout.</td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td>Connect with default options.</td></tr><tr><td valign="top"><a href="#start_link-1">start_link/1</a></td><td>Connect with the given options.</td></tr><tr><td valign="top"><a href="#start_link-2">start_link/2</a></td><td>Connect to the given host and port.</td></tr><tr><td valign="top"><a href="#start_link-3">start_link/3</a></td><td>(<em>Deprecated</em>.) </td></tr><tr><td valign="top"><a href="#start_link-4">start_link/4</a></td><td>(<em>Deprecated</em>.) </td></tr><tr><td valign="top"><a href="#start_link-5">start_link/5</a></td><td>(<em>Deprecated</em>.) </td></tr><tr><td valign="top"><a href="#start_link-6">start_link/6</a></td><td>(<em>Deprecated</em>.) </td></tr><tr><td valign="top"><a href="#start_link-7">start_link/7</a></td><td>(<em>Deprecated</em>.) </td></tr><tr><td valign="top"><a href="#stop-1">stop/1</a></td><td>Closes the connection and stops the client.</td></tr>
+</table>
 
 
 <a name="functions"></a>
@@ -101,8 +116,9 @@ specified connection.</td></tr><tr><td valign="top"><a href="#qp-3">qp/3</a></td
 
 <pre><code>
 q(Client::<a href="#type-client">client()</a>, Command::[any()]) -&gt; {ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::binary() | no_connection}
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Executes the given command in the specified connection. The
 command must be a valid Redis command and may contain arbitrary
@@ -115,8 +131,9 @@ always be binaries.
 
 <pre><code>
 q(Client::<a href="#type-client">client()</a>, Command::[any()], Timeout::integer()) -&gt; {ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::binary() | no_connection}
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Like q/2 with a custom timeout.
 
@@ -126,8 +143,9 @@ Like q/2 with a custom timeout.
 
 <pre><code>
 q_async(Client::<a href="#type-client">client()</a>, Command::[any()]) -&gt; ok
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Executes the command, and sends a message to the calling process with the
 response (with either error or success). Message is of the form `{response,
@@ -139,8 +157,9 @@ Reply}`, where `Reply` is the reply expected from `q/2`.
 
 <pre><code>
 q_async(Client::<a href="#type-client">client()</a>, Command::[any()], Pid::pid() | atom()) -&gt; ok
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Executes the command, and sends a message to `Pid` with the response
 (with either or success).
@@ -153,8 +172,9 @@ __See also:__ [q_async/2](#q_async-2).
 
 <pre><code>
 q_noreply(Client::<a href="#type-client">client()</a>, Command::[any()]) -&gt; ok
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Executes the command but does not wait for a response and ignores any
 errors.
@@ -167,8 +187,9 @@ __See also:__ [q/2](#q-2).
 
 <pre><code>
 qp(Client::<a href="#type-client">client()</a>, Pipeline::<a href="#type-pipeline">pipeline()</a>) -&gt; [{ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::binary()}] | {error, no_connection}
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Executes the given pipeline (list of commands) in the
 specified connection. The commands must be valid Redis commands and
@@ -181,8 +202,9 @@ values returned by each command in the pipeline are returned in a list.
 
 <pre><code>
 qp(Client::<a href="#type-client">client()</a>, Pipeline::<a href="#type-pipeline">pipeline()</a>, Timeout::integer()) -&gt; [{ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::binary()}] | {error, no_connection}
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Like qp/2 with a custom timeout.
 
@@ -192,8 +214,9 @@ Like qp/2 with a custom timeout.
 
 <pre><code>
 start_link() -&gt; {ok, Pid::pid()} | {error, Reason::term()}
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Equivalent to [`start_link([])`](#start_link-1).
 
@@ -205,8 +228,9 @@ Connect with default options.
 
 <pre><code>
 start_link(Options::<a href="#type-options">options()</a>) -&gt; {ok, pid()} | {error, Reason::term()}
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 `Options`: 
 
@@ -215,7 +239,8 @@ start_link(Options::<a href="#type-options">options()</a>) -&gt; {ok, pid()} | {
 
 
 <dd>DNS name or IP address as string; or unix domain
-  socket as <code>{local, Path}</code> (available in OTP 19+); default <code>"127.0.0.1"</code></dd>
+  socket as <code>{local, Path}</code> (available in OTP 19+); default <code>"127.0.0.1"</code>
+</dd>
 
 
 
@@ -223,7 +248,8 @@ start_link(Options::<a href="#type-options">options()</a>) -&gt; {ok, pid()} | {
 
 
 
-<dd>Integer, default is 6379</dd>
+<dd>Integer, default is 6379
+</dd>
 
 
 
@@ -232,7 +258,8 @@ start_link(Options::<a href="#type-options">options()</a>) -&gt; {ok, pid()} | {
 
 
 <dd>Integer (or string containing a number);
-  0 for default database</dd>
+  0 for default database
+</dd>
 
 
 
@@ -241,7 +268,8 @@ start_link(Options::<a href="#type-options">options()</a>) -&gt; {ok, pid()} | {
 
 
 <dd>String or empty string for no password;
-  default: <code>""</code> i.e. no password</dd>
+  default: <code>""</code> i.e. no password
+</dd>
 
 
 
@@ -250,7 +278,8 @@ start_link(Options::<a href="#type-options">options()</a>) -&gt; {ok, pid()} | {
 
 
 <dd>Integer of milliseconds to
-  sleep between reconnect attempts; default: 100</dd>
+  sleep between reconnect attempts; default: 100
+</dd>
 
 
 
@@ -259,7 +288,8 @@ start_link(Options::<a href="#type-options">options()</a>) -&gt; {ok, pid()} | {
 
 
 <dd>Timeout value in milliseconds to use
-  when connecting to Redis; default: 5000</dd>
+  when connecting to Redis; default: 5000
+</dd>
 
 
 
@@ -268,7 +298,8 @@ start_link(Options::<a href="#type-options">options()</a>) -&gt; {ok, pid()} | {
 
 
 <dd>List of<a href="https://erlang.org/doc/man/gen_tcp.md">gen_tcp options</a> used
-  when connecting the socket; default is <code>?SOCKET_OPTS</code></dd>
+  when connecting the socket; default is <code>?SOCKET_OPTS</code>
+</dd>
 
 
 
@@ -277,9 +308,10 @@ start_link(Options::<a href="#type-options">options()</a>) -&gt; {ok, pid()} | {
 
 
 <dd>Enabling TLS and a list of<a href="https://erlang.org/doc/man/ssl.md">ssl options</a>; used when
-  establishing a TLS connection; default is off</dd>
+  establishing a TLS connection; default is off
+</dd>
 
-<br />
+
 
 Connect with the given options.
 
@@ -289,8 +321,9 @@ Connect with the given options.
 
 <pre><code>
 start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Equivalent to [`start_link([{host, Host}, {port, Port}])`](#start_link-1).
 
@@ -302,7 +335,8 @@ Connect to the given host and port.
 
 <pre><code>
 start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, OptionsOrDatabase) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
-</code></pre>
+</code>
+</pre>
 
 <ul class="definitions"><li><code>OptionsOrDatabase = <a href="#type-options">options()</a> | string()</code></li></ul>
 
@@ -314,8 +348,9 @@ __This function is deprecated:__ Use [`start_link/1`](#start_link-1) instead.
 
 <pre><code>
 start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::string(), Password::string()) -&gt; {ok, pid()} | {error, term()}
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 __This function is deprecated:__ Use [`start_link/1`](#start_link-1) instead.
 
@@ -327,8 +362,9 @@ __See also:__ [start_link/1](#start_link-1).
 
 <pre><code>
 start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::string(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>) -&gt; {ok, pid()} | {error, term()}
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 __This function is deprecated:__ Use [`start_link/1`](#start_link-1) instead.
 
@@ -340,8 +376,9 @@ __See also:__ [start_link/1](#start_link-1).
 
 <pre><code>
 start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::string(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout()) -&gt; {ok, pid()} | {error, term()}
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 __This function is deprecated:__ Use [`start_link/1`](#start_link-1) instead.
 
@@ -353,8 +390,9 @@ __See also:__ [start_link/1](#start_link-1).
 
 <pre><code>
 start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::string(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout(), SocketOptions::list()) -&gt; {ok, pid()} | {error, term()}
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 __This function is deprecated:__ Use [`start_link/1`](#start_link-1) instead.
 
@@ -366,8 +404,9 @@ __See also:__ [start_link/1](#start_link-1).
 
 <pre><code>
 stop(Client::<a href="#type-client">client()</a>) -&gt; ok
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Closes the connection and stops the client.
 

--- a/doc/eredis_sub.md
+++ b/doc/eredis_sub.md
@@ -12,42 +12,50 @@
 
 
 
-### <a name="type-channel">channel()</a> ###
+<a name="type-channel"></a>
+### channel() ###
 
 
 <pre><code>
 channel() = binary()
-</code></pre>
+</code>
+</pre>
 
 
 
 
-### <a name="type-option">option()</a> ###
+<a name="type-option"></a>
+### option() ###
 
 
 <pre><code>
 option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer() | string()} | {password, string()} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]}
-</code></pre>
+</code>
+</pre>
 
 
 
 
-### <a name="type-options">options()</a> ###
+<a name="type-options"></a>
+### options() ###
 
 
 <pre><code>
 options() = [<a href="#type-option">option()</a>]
-</code></pre>
+</code>
+</pre>
 
 
 
 
-### <a name="type-reconnect_sleep">reconnect_sleep()</a> ###
+<a name="type-reconnect_sleep"></a>
+### reconnect_sleep() ###
 
 
 <pre><code>
 reconnect_sleep() = no_reconnect | integer()
-</code></pre>
+</code>
+</pre>
 
 <a name="index"></a>
 
@@ -56,7 +64,8 @@ reconnect_sleep() = no_reconnect | integer()
 
 <table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#ack_message-1">ack_message/1</a></td><td> acknowledge the receipt of a pubsub message.</td></tr><tr><td valign="top"><a href="#channels-1">channels/1</a></td><td> Returns the channels the given client is currently
 subscribing to.</td></tr><tr><td valign="top"><a href="#controlling_process-1">controlling_process/1</a></td><td> Make the calling process the controlling process.</td></tr><tr><td valign="top"><a href="#controlling_process-2">controlling_process/2</a></td><td> Make the given process (pid) the controlling process.</td></tr><tr><td valign="top"><a href="#controlling_process-3">controlling_process/3</a></td><td> Make the given process (pid) the controlling process subscriber
-with the given Timeout.</td></tr><tr><td valign="top"><a href="#psubscribe-2">psubscribe/2</a></td><td> Pattern subscribe to the given channels.</td></tr><tr><td valign="top"><a href="#punsubscribe-2">punsubscribe/2</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-1">start_link/1</a></td><td> Callback for starting from poolboy.</td></tr><tr><td valign="top"><a href="#start_link-3">start_link/3</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-6">start_link/6</a></td><td></td></tr><tr><td valign="top"><a href="#stop-1">stop/1</a></td><td></td></tr><tr><td valign="top"><a href="#subscribe-2">subscribe/2</a></td><td> Subscribe to the given channels.</td></tr><tr><td valign="top"><a href="#unsubscribe-2">unsubscribe/2</a></td><td></td></tr></table>
+with the given Timeout.</td></tr><tr><td valign="top"><a href="#psubscribe-2">psubscribe/2</a></td><td> Pattern subscribe to the given channels.</td></tr><tr><td valign="top"><a href="#punsubscribe-2">punsubscribe/2</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-1">start_link/1</a></td><td> Callback for starting from poolboy.</td></tr><tr><td valign="top"><a href="#start_link-3">start_link/3</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-6">start_link/6</a></td><td></td></tr><tr><td valign="top"><a href="#stop-1">stop/1</a></td><td></td></tr><tr><td valign="top"><a href="#subscribe-2">subscribe/2</a></td><td> Subscribe to the given channels.</td></tr><tr><td valign="top"><a href="#unsubscribe-2">unsubscribe/2</a></td><td></td></tr>
+</table>
 
 
 <a name="functions"></a>
@@ -69,8 +78,9 @@ with the given Timeout.</td></tr><tr><td valign="top"><a href="#psubscribe-2">ps
 
 <pre><code>
 ack_message(Client::pid()) -&gt; ok
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 acknowledge the receipt of a pubsub message. each pubsub
 message must be acknowledged before the next one is received
@@ -92,8 +102,9 @@ reflect the channels Redis thinks the client is subscribed to.
 
 <pre><code>
 controlling_process(Client::pid()) -&gt; ok
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Make the calling process the controlling process. The
 controlling process received pubsub-related messages, of which
@@ -135,8 +146,9 @@ pubsub messages. See ack_message/1.
 
 <pre><code>
 controlling_process(Client::pid(), Pid::pid()) -&gt; ok
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Make the given process (pid) the controlling process.
 
@@ -155,8 +167,9 @@ with the given Timeout.
 
 <pre><code>
 psubscribe(Client::pid(), Channels::[<a href="#type-channel">channel()</a>]) -&gt; ok
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Pattern subscribe to the given channels. Returns immediately. The
 result will be delivered to the controlling process as any other
@@ -168,8 +181,9 @@ message. Delivers {subscribed, Channel::binary(), pid()}
 
 <pre><code>
 punsubscribe(Client::pid(), Channels::[<a href="#type-channel">channel()</a>]) -&gt; ok
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 <a name="start_link-0"></a>
 
@@ -183,8 +197,9 @@ punsubscribe(Client::pid(), Channels::[<a href="#type-channel">channel()</a>]) -
 
 <pre><code>
 start_link(Args::<a href="#type-options">options()</a>) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Callback for starting from poolboy
 
@@ -212,8 +227,9 @@ Callback for starting from poolboy
 
 <pre><code>
 subscribe(Client::pid(), Channels::[<a href="#type-channel">channel()</a>]) -&gt; ok
-</code></pre>
-<br />
+</code>
+</pre>
+
 
 Subscribe to the given channels. Returns immediately. The
 result will be delivered to the controlling process as any other
@@ -225,6 +241,7 @@ message. Delivers {subscribed, Channel::binary(), pid()}
 
 <pre><code>
 unsubscribe(Client::pid(), Channels::[<a href="#type-channel">channel()</a>]) -&gt; ok
-</code></pre>
-<br />
+</code>
+</pre>
+
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,23 @@
 defmodule Eredis.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/Nordix/eredis/"
+  @version "1.3.1-nordix"
+
   def project do
     [
       app: :eredis,
-      version: "1.3.1-nordix",
+      deps: deps(),
+      description: "Non-blocking Redis client with focus on performance and robustness.",
       elixir: ">= 1.5.1",
-      start_permanent: Mix.env == :prod,
-      deps: deps()
+      package: package(),
+      source_url: @source_url,
+      start_permanent: Mix.env() == :prod,
+      version: @version,
+      docs: [
+        main: "readme",
+        extras: ["README.md", "CHANGELOG.md", "doc/eredis.md", "doc/eredis_sub.md"]
+      ]
     ]
   end
 
@@ -18,6 +28,16 @@ defmodule Eredis.Mixfile do
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
-    []
+    [
+      {:ex_doc, "~> 0.22", only: :dev, runtime: false}
+    ]
+  end
+
+  defp package() do
+    [
+      maintainers: ["Viktor Söderqvist", "Bjorn Svensson"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source_url}
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,8 @@ defmodule Eredis.Mixfile do
       version: @version,
       docs: [
         main: "readme",
-        extras: ["README.md", "CHANGELOG.md", "doc/eredis.md", "doc/eredis_sub.md"]
+        extras: ["README.md", "CHANGELOG.md", "doc/eredis.md", "doc/eredis_sub.md"],
+        api_reference: false
       ]
     ]
   end
@@ -29,7 +30,9 @@ defmodule Eredis.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_doc, "~> 0.22", only: :dev, runtime: false}
+      # Use latest version of ex_doc to create correct tables
+      # {:ex_doc, "~> 0.22", only: :dev, runtime: false}
+      {:ex_doc, git: "https://github.com/elixir-lang/ex_doc.git", tag: "master", only: :dev, runtime: false}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Eredis.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/Nordix/eredis/"
-  @version "1.3.1-nordix"
+  @version "1.3.2"
 
   def project do
     [

--- a/src/eredis.app.src
+++ b/src/eredis.app.src
@@ -1,6 +1,6 @@
 {application,eredis,
              [{description,"Erlang Redis Client"},
-              {vsn,"1.3.1-nordix"},
+              {vsn,"1.3.2"},
               {modules,[eredis,eredis_client,eredis_parser,eredis_sub,
                         eredis_sub_client]},
               {registered,[]},


### PR DESCRIPTION
This is a continuation of #29 and #30, i.e using Alexandres changes but with needed patching of the markdown files.
This gives a documentation on hexdocs that are similar to the checked in result viewable on github.

Documentation is patched and both package and documentation is published by running:
`make publish`
