### PR TITLE
Corrections for publishing a hex package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v1.3.3
+
+March 2021.
+
+* Include correct files in published package on hex.pm.
+
 ## v1.3.2
 
 February 2021.

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ publish: edoc
 		echo "Error: Working directory is dirty. Please commit before publish!"; \
 		exit 1; \
 	fi
-	mix hex.publish package
+	mix hex.publish
 
 xref:
 	@rebar3 xref

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Eredis.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/Nordix/eredis/"
-  @version "1.3.2"
+  @version "1.3.3"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule Eredis.Mixfile do
 
   defp package() do
     [
+      files: ["src", "include", "mix.exs", "rebar.config", "AUTHORS", "CHANGELOG.md", "LICENSE", "README.md"],
       maintainers: ["Viktor Söderqvist", "Bjorn Svensson"],
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url}

--- a/src/eredis.app.src
+++ b/src/eredis.app.src
@@ -1,6 +1,6 @@
 {application,eredis,
              [{description,"Erlang Redis Client"},
-              {vsn,"1.3.2"},
+              {vsn,"1.3.3"},
               {modules,[eredis,eredis_client,eredis_parser,eredis_sub,
                         eredis_sub_client]},
               {registered,[]},


### PR DESCRIPTION
* Publish specific files to make sure we can build with both rebar3 and mix.
* Publish both package and docs via build target