### PR TITLE
Support AUTH with username

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ takes the following options (proplist):
   Path}` (available in OTP 19+)
 * `port`: integer, default is 6379
 * `database`: integer or 0 for default database, default: 0
-* `password`: string or empty string for no password, default: "" i.e. no password
+* `username`: string, default: no username
+* `password`: string, default: no password
 * `reconnect_sleep`: integer of milliseconds to sleep between reconnect attempts, default: 100
 * `connect_timeout`: timeout value in milliseconds to use in the connect, default: 5000
 * `socket_options`: proplist of [gen_tcp](https://erlang.org/doc/man/gen_tcp.html)

--- a/doc/eredis.md
+++ b/doc/eredis.md
@@ -263,12 +263,20 @@ start_link(Options::<a href="#type-options">options()</a>) -&gt; {ok, pid()} | {
 
 
 
+<dt><code>{username, Username}</code></dt>
+
+
+
+<dd>String; default: no username
+</dd>
+
+
+
 <dt><code>{password, Password}</code></dt>
 
 
 
-<dd>String or empty string for no password;
-  default: <code>""</code> i.e. no password
+<dd>String; default: no password
 </dd>
 
 

--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -18,7 +18,7 @@
 -export([q/2, q/3, qp/2, qp/3, q_noreply/2, q_async/2, q_async/3]).
 -export_type([options/0]).
 
-%% Exported for eredis_sub_client and testing
+%% Exported for eredis_client, eredis_sub_client and testing
 -export([create_multibulk/1]).
 
 %% Type of gen_server process id
@@ -49,8 +49,8 @@ start_link() ->
 %% <dt>`{port, Port}'</dt><dd>Integer, default is 6379</dd>
 %% <dt>`{database, Database}'</dt><dd>Integer (or string containing a number);
 %% 0 for default database</dd>
-%% <dt>`{password, Password}'</dt><dd>String or empty string for no password;
-%% default: `""' i.e. no password</dd>
+%% <dt>`{username, Username}'</dt><dd>String; default: no username</dd>
+%% <dt>`{password, Password}'</dt><dd>String; default: no password</dd>
 %% <dt>`{reconnect_sleep, ReconnectSleep}'</dt><dd>Integer of milliseconds to
 %% sleep between reconnect attempts; default: 100</dd>
 %% <dt>`{connect_timeout, Timeout}'</dt><dd>Timeout value in milliseconds to use


### PR DESCRIPTION
A username can be supplied in options. Username and password can
now contain any characters, including quotes and newlines.

Fixes #35