### PR TITLE
Support named connection PIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v1.4.0
+
+June 2021.
+
+* Add support for named connection processes.
+
 ## v1.3.3
 
 March 2021.

--- a/doc/eredis.md
+++ b/doc/eredis.md
@@ -41,7 +41,7 @@ host() = string() | {local, string()}
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer() | string()} | {password, string()} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]}
+option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer() | string()} | {password, string()} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>}
 </code>
 </pre>
 
@@ -78,6 +78,18 @@ pipeline() = [iolist()]
 
 <pre><code>
 reconnect_sleep() = no_reconnect | integer()
+</code>
+</pre>
+
+
+
+
+<a name="type-registered_name"></a>
+### registered_name() ###
+
+
+<pre><code>
+registered_name() = {local, atom()} | {global, term()} | {via, atom(), term()}
 </code>
 </pre>
 
@@ -317,6 +329,17 @@ start_link(Options::<a href="#type-options">options()</a>) -&gt; {ok, pid()} | {
 
 <dd>Enabling TLS and a list of<a href="https://erlang.org/doc/man/ssl.md">ssl options</a>; used when
   establishing a TLS connection; default is off
+</dd>
+
+
+
+<dt><code>{name, Name}</code></dt>
+
+
+
+<dd>Tuple to register the client with a name
+  such as <code>{local, atom()}</code>; for all options see <code>ServerName</code> at<a href="https://erlang.org/doc/man/gen_server.md#start_link-4">gen_server:start_link/4</a>;
+  default: no name
 </dd>
 
 

--- a/doc/eredis_sub.md
+++ b/doc/eredis_sub.md
@@ -29,7 +29,7 @@ channel() = binary()
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer() | string()} | {password, string()} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]}
+option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer() | string()} | {password, string()} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>}
 </code>
 </pre>
 
@@ -54,6 +54,18 @@ options() = [<a href="#type-option">option()</a>]
 
 <pre><code>
 reconnect_sleep() = no_reconnect | integer()
+</code>
+</pre>
+
+
+
+
+<a name="type-registered_name"></a>
+### registered_name() ###
+
+
+<pre><code>
+registered_name() = {local, atom()} | {global, term()} | {via, atom(), term()}
 </code>
 </pre>
 

--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -1,6 +1,7 @@
 %% Public types
 
 -type reconnect_sleep() :: no_reconnect | integer().
+-type registered_name() :: {local, atom()} | {global, term()} | {via, atom(), term()}.
 
 -type option() :: {host, string() | {local, string()}} |
                   {port, inet:port_number()} |
@@ -9,7 +10,8 @@
                   {reconnect_sleep, reconnect_sleep()} |
                   {connect_timeout, integer()} |
                   {socket_options, list()} |
-                  {tls, [ssl:tls_client_option()]}.
+                  {tls, [ssl:tls_client_option()]} |
+                  {name, registered_name()}.
 
 -type options() :: [option()].
 -type server_args() :: options().               % for backwards compatibility

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Eredis.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/Nordix/eredis/"
-  @version "1.3.3"
+  @version "1.4.0"
 
   def project do
     [

--- a/src/eredis.app.src
+++ b/src/eredis.app.src
@@ -1,6 +1,6 @@
 {application,eredis,
              [{description,"Erlang Redis Client"},
-              {vsn,"1.3.3"},
+              {vsn,"1.4.0"},
               {modules,[eredis,eredis_client,eredis_parser,eredis_sub,
                         eredis_sub_client]},
               {registered,[]},

--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -61,6 +61,10 @@ start_link() ->
 %% <dt>`{tls, TlsOpts}'</dt><dd>Enabling TLS and a list of
 %% <a href="https://erlang.org/doc/man/ssl.html">ssl options</a>; used when
 %% establishing a TLS connection; default is off</dd>
+%% <dt>`{name, Name}'</dt><dd>Tuple to register the client with a name
+%% such as `{local, atom()}'; for all options see `ServerName' at
+%% <a href="https://erlang.org/doc/man/gen_server.html#start_link-4">gen_server:start_link/4</a>;
+%% default: no name</dd>
 %% </dl>
 -spec start_link(options()) -> {ok, pid()} | {error, Reason::term()}.
 start_link(Options) ->

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -61,7 +61,12 @@
 -spec start_link(Options::options()) ->
           {ok, Pid::pid()} | {error, Reason::term()}.
 start_link(Options) ->
-    gen_server:start_link(?MODULE, Options, []).
+    case proplists:lookup(name, Options) of
+        {name, Name} ->
+            gen_server:start_link(Name, ?MODULE, Options, []);
+        none ->
+            gen_server:start_link(?MODULE, Options, [])
+    end.
 
 
 stop(Pid) ->


### PR DESCRIPTION
Hi,

First off, thank you for maintaining the library!

I thought I would open a PR to add the possibility to name connection PIDs.
I didn't know what the best solution would have been to add naming to `start_link/2,3,4,5,6,7` so for now this would only be supported by `start_link/1` by adding `{name, {local, my_redis_connection}}` (or similar) to the argument proplist.
"It ain't much, but it's honest work"