### PR TITLE
eredis_sub: Re-subscribe to channels after reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v1.5.0
+
+Not yet released.
+
+* eredis_sub: Automatic re-subscribe on reconnect. Messages on the
+  form `{subscribed, Channel, Pid}` are sent to the controlling
+  process in this case and need to be acked.
+
+* eredis_sub: TLS, custom TCP options, AUTH with username, SELECT
+  database and registered name options added.
+
 ## v1.4.1
 
 June 2021.

--- a/include/eredis_sub.hrl
+++ b/include/eredis_sub.hrl
@@ -14,6 +14,7 @@
 
           %% Channels we should subscribe to
           channels = [] :: [channel()],
+          pchannels = [] :: [channel()], % psubscribe
 
           %% The process we send pubsub and connection state messages to.
           controlling_process :: undefined | {reference(), pid()},

--- a/src/eredis_sub_client.erl
+++ b/src/eredis_sub_client.erl
@@ -288,7 +288,11 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%--------------------------------------------------------------------
 
+%% @doc When no channels are given, we unsubscribe from all channels. This
+%% matches the semantics of (P)UNSUBSCRIBE without channels.
 -spec remove_channels([binary()], [binary()]) -> [binary()].
+remove_channels([], _OldChannels) ->
+    [];
 remove_channels(Channels, OldChannels) ->
     lists:foldl(fun lists:delete/2, OldChannels, Channels).
 

--- a/test/eredis_pubsub_SUITE.erl
+++ b/test/eredis_pubsub_SUITE.erl
@@ -232,7 +232,7 @@ t_reconnect_resubscribe(Config) when is_list(Config) ->
     ?assertEqual({subscribed, <<"pat1*">>, Sub}, wait_for_msg(S)),
     ?assertEqual({subscribed, <<"pat2*">>, Sub}, wait_for_msg(S)),
 
-    %% Test publish and recieve message.
+    %% Test publish and receive message.
     eredis:q(Pub, ["PUBLISH", "chan1", "hello"]),
     eredis:q(Pub, ["PUBLISH", "pat2-banana", "world"]),
     ?assertEqual({message, <<"chan1">>, <<"hello">>, Sub},

--- a/test/eredis_pubsub_SUITE.erl
+++ b/test/eredis_pubsub_SUITE.erl
@@ -172,11 +172,17 @@ t_dynamic_channels(Config) when is_list(Config) ->
     eredis:q(Pub, [publish, otherchan, foo]),
     ?assertEqual([{message, <<"otherchan">>, <<"foo">>, Sub}], recv_all(Sub)),
 
+    %% Unsubscribe one.
     eredis_sub:unsubscribe(Sub, [<<"otherchan">>]),
-    eredis_sub:ack_message(Sub),
     receive M3 -> ?assertEqual({unsubscribed, <<"otherchan">>, Sub}, M3) end,
+    eredis_sub:ack_message(Sub),
+    ?assertEqual({ok, [<<"newchan">>]}, eredis_sub:channels(Sub)),
 
-    ?assertEqual({ok, [<<"newchan">>]}, eredis_sub:channels(Sub)).
+    %% Unsubscribe all.
+    eredis_sub:unsubscribe(Sub, []),
+    receive M4 -> ?assertEqual({unsubscribed, <<"newchan">>, Sub}, M4) end,
+    eredis_sub:ack_message(Sub),
+    ?assertEqual({ok, []}, eredis_sub:channels(Sub)).
 
 % Tests for Pattern Subscribe
 t_pubsub_pattern(Config) when is_list(Config) ->


### PR DESCRIPTION
Automatically send SUBSCRIBE and PSUBSCRIBE for the subscribed channels
after reconnect. Notification on the form of subscribed-tuples are
delivered to the controlling process.

After reconnecting, the controlling process will get messages on the
form `{subscribed, _, _}` which need to be acked.

Fixes #50.