### PR TITLE
No delay before reconnect

### DIFF
--- a/src/eredis_sub_client.erl
+++ b/src/eredis_sub_client.erl
@@ -215,13 +215,22 @@ handle_info({Closed, Socket}, #state{socket = OurSocket} = State)
        Socket =:= OurSocket orelse Socket =:= fake_socket ->
     maybe_reconnect(Closed, State);
 
-handle_info(initiate_connection, #state{socket = undefined} = State) ->
+handle_info(initiate_connection,
+            #state{socket = undefined,
+                   reconnect_sleep = ReconnectSleep} = State) ->
     case connect(State) of
         {ok, NewState} ->
             {noreply, NewState};
+        {error, _Reason} when ReconnectSleep =:= no_reconnect ->
+            {stop, normal, State};
         {error, Reason} ->
-            maybe_reconnect(Reason, State)
+            erlang:send_after(ReconnectSleep, self(), {reconnect, Reason}),
+            {noreply, State}
     end;
+
+handle_info({reconnect, Reason}, #state{socket = undefined} = State) ->
+    %% Scheduled reconnect
+    maybe_reconnect(Reason, State);
 
 %% Controller might want to be notified about every reconnect attempt
 handle_info(reconnect_attempt, State) ->

--- a/test/eredis_tcp_SUITE.erl
+++ b/test/eredis_tcp_SUITE.erl
@@ -423,7 +423,7 @@ t_tcp_closed(Config) when is_list(Config) ->
     {ok, C} = eredis:start_link([{reconnect_sleep, 10000}]),
     ?assertMatch({ok, _}, eredis:q(C, ["DEL", foo], 5000)),
     tcp_closed_rig(C),
-    timer:sleep(100), % Instant reconnect. No sleep before the first attemt.
+    timer:sleep(100), % Instant reconnect. No sleep before the first attempt.
     ?assertMatch({ok, _}, eredis:q(C, ["DEL", foo], 5000)),
     ?assertMatch(ok, eredis:stop(C)).
 

--- a/test/eredis_tcp_SUITE.erl
+++ b/test/eredis_tcp_SUITE.erl
@@ -420,10 +420,10 @@ t_unknown_client_cast(Config) when is_list(Config) ->
     ?assertMatch(ok, eredis:stop(C)).
 
 t_tcp_closed(Config) when is_list(Config) ->
-    C = c(),
+    {ok, C} = eredis:start_link([{reconnect_sleep, 10000}]),
     ?assertMatch({ok, _}, eredis:q(C, ["DEL", foo], 5000)),
     tcp_closed_rig(C),
-    timer:sleep(200), %% Wait for reconnection (after ~100ms)
+    timer:sleep(100), % Instant reconnect. No sleep before the first attemt.
     ?assertMatch({ok, _}, eredis:q(C, ["DEL", foo], 5000)),
     ?assertMatch(ok, eredis:stop(C)).
 


### PR DESCRIPTION
When the connection is lost, attempt to reconnect immediately.

Waiting `reconnect_sleep` milliseconds should be only *between*
reconnects attempts, not before the first reconnect attempt.

Fixes #51.