### PR TITLE
Correction for re-connection process exit

### DIFF
--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -580,7 +580,7 @@ reconnect_loop(Client, ReconnectSleep, Host, Port, SocketOptions,
         {error, Reason} ->
             Client ! {reconnect_failed, Reason},
             receive
-                {'EXIT', Client, Reason} -> exit(Reason)
+                {'EXIT', Client, Reason2} -> exit(Reason2)
             after
                 ReconnectSleep ->
                     reconnect_loop(Client, ReconnectSleep, Host, Port,

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -580,7 +580,7 @@ reconnect_loop(Client, ReconnectSleep, Host, Port, SocketOptions,
         {error, Reason} ->
             Client ! {reconnect_failed, Reason},
             receive
-                {'EXIT', Client, Reason2} -> exit(Reason2)
+                {'EXIT', Client, ExitReason} -> exit(ExitReason)
             after
                 ReconnectSleep ->
                     reconnect_loop(Client, ReconnectSleep, Host, Port,


### PR DESCRIPTION
Correction  for #51
`Reason` was already used, which resulted in that the re-connection process was never stopped.