### PR TITLE
Reconnect in the same process

### DIFF
--- a/include/eredis_sub.hrl
+++ b/include/eredis_sub.hrl
@@ -10,6 +10,7 @@
 
           transport :: gen_tcp | ssl,
           socket :: gen_tcp:socket() | ssl:sslsocket() | undefined,
+          reconnect_timer :: reference() | undefined,
           parser_state :: #pstate{} | undefined,
 
           %% Channels we should subscribe to

--- a/test/eredis_tcp_SUITE.erl
+++ b/test/eredis_tcp_SUITE.erl
@@ -420,11 +420,12 @@ t_unknown_client_cast(Config) when is_list(Config) ->
     ?assertMatch(ok, eredis:stop(C)).
 
 t_tcp_closed(Config) when is_list(Config) ->
-    {ok, C} = eredis:start_link([{reconnect_sleep, 10000}]),
-    ?assertMatch({ok, _}, eredis:q(C, ["DEL", foo], 5000)),
+    {ok, C} = eredis:start_link([{reconnect_sleep, 1000}]),
+    timer:sleep(1000), % Reconnect prevented during grace period.
+    ?assertMatch({ok, _}, eredis:q(C, ["DEL", foo], 500)),
     tcp_closed_rig(C),
     timer:sleep(100), % Instant reconnect. No sleep before the first attempt.
-    ?assertMatch({ok, _}, eredis:q(C, ["DEL", foo], 5000)),
+    ?assertMatch({ok, _}, eredis:q(C, ["DEL", foo], 500)),
     ?assertMatch(ok, eredis:stop(C)).
 
 t_connect_no_reconnect(Config) when is_list(Config) ->


### PR DESCRIPTION
This commit drops the spawned process used for reconnecting. Instead,
the reconnect attempts are scheduled using timers.

The option `reconnect_sleep` now applies to the time between a
successful connect and the first reconnect, if the connection is lost
just after connecting. However, there is no delay before reconnecting
if the connection has been up for at least reconnect_sleep milliseconds.