### PR TITLE
Fix crash when reconnect fails again with different reason

### DIFF
--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -574,8 +574,8 @@ maybe_reconnect(Reason,
     case connect(State1) of
         {ok, State2} ->
             {noreply, State2};
-        {error, Reason} ->
-            {noreply, schedule_reconnect(Reason, State1)}
+        {error, NewReason} ->
+            {noreply, schedule_reconnect(NewReason, State1)}
     end.
 
 read_database(undefined) ->


### PR DESCRIPTION
When reconnect fails with a different reason than the previous
reconnect reason, there was a crash because the Reason variable
was unintentionally reused.

Fixes #58