### PR TITLE
Obfuscate secrets in state

### DIFF
--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -6,8 +6,8 @@
 -type option() :: {host, string() | {local, string()}} |
                   {port, inet:port_number()} |
                   {database, integer()} |
-                  {username, string()} |
-                  {password, string()} |
+                  {username, iodata() | fun(() -> iodata()) | undefined} |
+                  {password, iodata() | fun(() -> iodata()) | undefined} |
                   {reconnect_sleep, reconnect_sleep()} |
                   {connect_timeout, integer()} |
                   {socket_options, list()} |

--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -6,6 +6,7 @@
 -type option() :: {host, string() | {local, string()}} |
                   {port, inet:port_number()} |
                   {database, integer()} |
+                  {username, string()} |
                   {password, string()} |
                   {reconnect_sleep, reconnect_sleep()} |
                   {connect_timeout, integer()} |

--- a/include/eredis_sub.hrl
+++ b/include/eredis_sub.hrl
@@ -2,7 +2,7 @@
           host :: string() | undefined,
           port :: integer() | undefined,
           database :: binary() | undefined,
-          auth_cmd :: iodata() | undefined,
+          auth_cmd :: fun(() -> iodata()) | undefined,
           reconnect_sleep :: integer() | undefined | no_reconnect,
           connect_timeout :: integer() | undefined,
           socket_options :: list(),

--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -48,10 +48,14 @@ start_link() ->
 %% socket as `{local, Path}' (available in OTP 19+); default `"127.0.0.1"'</dd>
 %% <dt>`{port, Port}'</dt><dd>Integer, default is 6379</dd>
 %% <dt>`{database, Database}'</dt><dd>Integer; 0 for the default database</dd>
-%% <dt>`{username, Username}'</dt><dd>String or a 0-ary function that returns
-%% the username; default: no username</dd>
-%% <dt>`{password, Password}'</dt><dd>String or a 0-ary function that returns
-%% the password; default: no password</dd>
+%% <dt>`{username, Username}'</dt><dd>A 0-ary function that returns the username
+%% (the preferred way to provide username as it prevent the actual secret from
+%% appearing in logs and stacktraces), a string or iodata or the atom
+%% `undefined' for no username; default `undefined'</dd>
+%% <dt>`{password, Password}'</dt><dd>A 0-ary function that returns the password
+%% (the preferred way to provide password as it prevent the actual secret from
+%% appearing in logs and stacktraces), a string or iodata or the atom
+%% `undefined' for no username; default `undefined'</dd>
 %% <dt>`{reconnect_sleep, ReconnectSleep}'</dt><dd>Integer of milliseconds to
 %% sleep between reconnect attempts; default: 100</dd>
 %% <dt>`{connect_timeout, Timeout}'</dt><dd>Timeout value in milliseconds to use

--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -49,11 +49,11 @@ start_link() ->
 %% <dt>`{port, Port}'</dt><dd>Integer, default is 6379</dd>
 %% <dt>`{database, Database}'</dt><dd>Integer; 0 for the default database</dd>
 %% <dt>`{username, Username}'</dt><dd>A 0-ary function that returns the username
-%% (the preferred way to provide username as it prevent the actual secret from
+%% (the preferred way to provide username as it prevents the actual secret from
 %% appearing in logs and stacktraces), a string or iodata or the atom
 %% `undefined' for no username; default `undefined'</dd>
 %% <dt>`{password, Password}'</dt><dd>A 0-ary function that returns the password
-%% (the preferred way to provide password as it prevent the actual secret from
+%% (the preferred way to provide password as it prevents the actual secret from
 %% appearing in logs and stacktraces), a string or iodata or the atom
 %% `undefined' for no username; default `undefined'</dd>
 %% <dt>`{reconnect_sleep, ReconnectSleep}'</dt><dd>Integer of milliseconds to

--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -48,8 +48,10 @@ start_link() ->
 %% socket as `{local, Path}' (available in OTP 19+); default `"127.0.0.1"'</dd>
 %% <dt>`{port, Port}'</dt><dd>Integer, default is 6379</dd>
 %% <dt>`{database, Database}'</dt><dd>Integer; 0 for the default database</dd>
-%% <dt>`{username, Username}'</dt><dd>String; default: no username</dd>
-%% <dt>`{password, Password}'</dt><dd>String; default: no password</dd>
+%% <dt>`{username, Username}'</dt><dd>String or a 0-ary function that returns
+%% the username; default: no username</dd>
+%% <dt>`{password, Password}'</dt><dd>String or a 0-ary function that returns
+%% the password; default: no password</dd>
 %% <dt>`{reconnect_sleep, ReconnectSleep}'</dt><dd>Integer of milliseconds to
 %% sleep between reconnect attempts; default: 100</dd>
 %% <dt>`{connect_timeout, Timeout}'</dt><dd>Timeout value in milliseconds to use

--- a/src/eredis_sub.erl
+++ b/src/eredis_sub.erl
@@ -56,8 +56,10 @@ start_link(Host, Port, Password, ReconnectSleep,
 %% socket as `{local, Path}' (available in OTP 19+); default `"127.0.0.1"'</dd>
 %% <dt>`{port, Port}'</dt><dd>Integer, default is 6379</dd>
 %% <dt>`{database, Database}'</dt><dd>Integer; 0 for the default database</dd>
-%% <dt>`{username, Username}'</dt><dd>String; default: no username</dd>
-%% <dt>`{password, Password}'</dt><dd>String; default: no password</dd>
+%% <dt>`{username, Username}'</dt><dd>String or a 0-ary function that returns
+%% the username; default: no username</dd>
+%% <dt>`{password, Password}'</dt><dd>String or a 0-ary function that returns
+%% the password; default: no password</dd>
 %% <dt>`{reconnect_sleep, ReconnectSleep}'</dt><dd>Integer of milliseconds to
 %% sleep between reconnect attempts; default: 100</dd>
 %% <dt>`{connect_timeout, Timeout}'</dt><dd>Timeout value in milliseconds to use

--- a/src/eredis_sub.erl
+++ b/src/eredis_sub.erl
@@ -56,10 +56,14 @@ start_link(Host, Port, Password, ReconnectSleep,
 %% socket as `{local, Path}' (available in OTP 19+); default `"127.0.0.1"'</dd>
 %% <dt>`{port, Port}'</dt><dd>Integer, default is 6379</dd>
 %% <dt>`{database, Database}'</dt><dd>Integer; 0 for the default database</dd>
-%% <dt>`{username, Username}'</dt><dd>String or a 0-ary function that returns
-%% the username; default: no username</dd>
-%% <dt>`{password, Password}'</dt><dd>String or a 0-ary function that returns
-%% the password; default: no password</dd>
+%% <dt>`{username, Username}'</dt><dd>A 0-ary function that returns the username
+%% (the preferred way to provide username as it prevent the actual secret from
+%% appearing in logs and stacktraces), a string or iodata or the atom
+%% `undefined' for no username; default `undefined'</dd>
+%% <dt>`{password, Password}'</dt><dd>A 0-ary function that returns the password
+%% (the preferred way to provide password as it prevent the actual secret from
+%% appearing in logs and stacktraces), a string or iodata or the atom
+%% `undefined' for no username; default `undefined'</dd>
 %% <dt>`{reconnect_sleep, ReconnectSleep}'</dt><dd>Integer of milliseconds to
 %% sleep between reconnect attempts; default: 100</dd>
 %% <dt>`{connect_timeout, Timeout}'</dt><dd>Timeout value in milliseconds to use

--- a/src/eredis_sub.erl
+++ b/src/eredis_sub.erl
@@ -57,11 +57,11 @@ start_link(Host, Port, Password, ReconnectSleep,
 %% <dt>`{port, Port}'</dt><dd>Integer, default is 6379</dd>
 %% <dt>`{database, Database}'</dt><dd>Integer; 0 for the default database</dd>
 %% <dt>`{username, Username}'</dt><dd>A 0-ary function that returns the username
-%% (the preferred way to provide username as it prevent the actual secret from
+%% (the preferred way to provide username as it prevents the actual secret from
 %% appearing in logs and stacktraces), a string or iodata or the atom
 %% `undefined' for no username; default `undefined'</dd>
 %% <dt>`{password, Password}'</dt><dd>A 0-ary function that returns the password
-%% (the preferred way to provide password as it prevent the actual secret from
+%% (the preferred way to provide password as it prevents the actual secret from
 %% appearing in logs and stacktraces), a string or iodata or the atom
 %% `undefined' for no username; default `undefined'</dd>
 %% <dt>`{reconnect_sleep, ReconnectSleep}'</dt><dd>Integer of milliseconds to


### PR DESCRIPTION
Username and password are hidden in funs which are applied just when they are needed. This prevents the secrets from appearing verbatim in logs, stack traces, etc.

Fixes #63