### PR TITLE
Erlang formatter in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,25 @@ on:
       - master
 
 jobs:
+  fmt:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare
+        run: |
+          sudo apt update
+          sudo apt install emacs-nox
+      - name: Run erlang-formatter
+        run: |
+          rebar3 fmt
+          status="$(git status --untracked-file=no --porcelain)"
+          if [ ! -z "$status" ]; \
+          then \
+             echo "Error: Please format the following files (e.g. run 'rebar3 fmt')"; \
+             echo "$status"; \
+             exit 1; \
+          fi
+
   ci:
     strategy:
       matrix:

--- a/doc/eredis.md
+++ b/doc/eredis.md
@@ -41,7 +41,7 @@ host() = string() | {local, string()}
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | fun(() -&gt; iodata()) | undefined} | {password, iodata() | fun(() -&gt; iodata()) | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
+option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-secret">secret()</a> | undefined} | {password, iodata() | <a href="#type-secret">secret()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
 </code>
 </pre>
 
@@ -102,6 +102,18 @@ registered_name() = {local, atom()} | {global, term()} | {via, atom(), term()}
 
 <pre><code>
 return_value() = undefined | binary() | [binary() | nonempty_list()]
+</code>
+</pre>
+
+
+
+
+<a name="type-secret"></a>
+### secret() ###
+
+
+<pre><code>
+secret() = fun(() -&gt; iodata())
 </code>
 </pre>
 

--- a/doc/eredis.md
+++ b/doc/eredis.md
@@ -36,12 +36,24 @@ host() = string() | {local, string()}
 
 
 
+<a name="type-obfuscated"></a>
+### obfuscated() ###
+
+
+<pre><code>
+obfuscated() = fun(() -&gt; iodata())
+</code>
+</pre>
+
+
+
+
 <a name="type-option"></a>
 ### option() ###
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-secret">secret()</a> | undefined} | {password, iodata() | <a href="#type-secret">secret()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
+option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
 </code>
 </pre>
 
@@ -102,18 +114,6 @@ registered_name() = {local, atom()} | {global, term()} | {via, atom(), term()}
 
 <pre><code>
 return_value() = undefined | binary() | [binary() | nonempty_list()]
-</code>
-</pre>
-
-
-
-
-<a name="type-secret"></a>
-### secret() ###
-
-
-<pre><code>
-secret() = fun(() -&gt; iodata())
 </code>
 </pre>
 

--- a/doc/eredis_sub.md
+++ b/doc/eredis_sub.md
@@ -29,7 +29,7 @@ channel() = binary()
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | fun(() -&gt; iodata()) | undefined} | {password, iodata() | fun(() -&gt; iodata()) | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
+option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-secret">secret()</a> | undefined} | {password, iodata() | <a href="#type-secret">secret()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
 </code>
 </pre>
 
@@ -54,6 +54,18 @@ reconnect_sleep() = no_reconnect | integer()
 
 <pre><code>
 registered_name() = {local, atom()} | {global, term()} | {via, atom(), term()}
+</code>
+</pre>
+
+
+
+
+<a name="type-secret"></a>
+### secret() ###
+
+
+<pre><code>
+secret() = fun(() -&gt; iodata())
 </code>
 </pre>
 

--- a/doc/eredis_sub.md
+++ b/doc/eredis_sub.md
@@ -24,12 +24,24 @@ channel() = binary()
 
 
 
+<a name="type-obfuscated"></a>
+### obfuscated() ###
+
+
+<pre><code>
+obfuscated() = fun(() -&gt; iodata())
+</code>
+</pre>
+
+
+
+
 <a name="type-option"></a>
 ### option() ###
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-secret">secret()</a> | undefined} | {password, iodata() | <a href="#type-secret">secret()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
+option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
 </code>
 </pre>
 
@@ -54,18 +66,6 @@ reconnect_sleep() = no_reconnect | integer()
 
 <pre><code>
 registered_name() = {local, atom()} | {global, term()} | {via, atom(), term()}
-</code>
-</pre>
-
-
-
-
-<a name="type-secret"></a>
-### secret() ###
-
-
-<pre><code>
-secret() = fun(() -&gt; iodata())
 </code>
 </pre>
 

--- a/elvis.config
+++ b/elvis.config
@@ -19,8 +19,8 @@
                    , {elvis_style, no_nested_try_catch}
                    , {elvis_style, used_ignored_variable}
                    , {elvis_style, no_behavior_info}
-                   %% , {elvis_style, state_record_and_type}
-                   %% , {elvis_style, no_spec_with_records}
+                     %% , {elvis_style, state_record_and_type}
+                     %% , {elvis_style, no_spec_with_records}
                    , {elvis_style, dont_repeat_yourself,
                       #{ min_complexity => 18
                        }}

--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -1,13 +1,14 @@
 %% Public types
 
+-type secret() :: fun(() -> iodata()).
 -type reconnect_sleep() :: no_reconnect | integer().
 -type registered_name() :: {local, atom()} | {global, term()} | {via, atom(), term()}.
 
 -type option() :: {host, string() | {local, string()}} |
                   {port, inet:port_number()} |
                   {database, integer()} |
-                  {username, iodata() | fun(() -> iodata()) | undefined} |
-                  {password, iodata() | fun(() -> iodata()) | undefined} |
+                  {username, iodata() | secret() | undefined} |
+                  {password, iodata() | secret() | undefined} |
                   {reconnect_sleep, reconnect_sleep()} |
                   {connect_timeout, integer()} |
                   {socket_options, list()} |

--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -50,9 +50,7 @@
 
 %% Internal parser state. Is returned from parse/2 and must be
 %% included on the next calls to parse/2.
--record(pstate, {
-                 states = [] :: [continuation_data()]
-                }).
+-record(pstate, {states = [] :: [continuation_data()]}).
 
 -define(NL, "\r\n").
 -define(NL_KEY, eredis_newline_pattern).

--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -51,8 +51,8 @@
 %% Internal parser state. Is returned from parse/2 and must be
 %% included on the next calls to parse/2.
 -record(pstate, {
-          states = [] :: [continuation_data()]
-}).
+                 states = [] :: [continuation_data()]
+                }).
 
 -define(NL, "\r\n").
 -define(NL_KEY, eredis_newline_pattern).

--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -1,14 +1,14 @@
 %% Public types
 
--type secret() :: fun(() -> iodata()).
+-type obfuscated() :: fun(() -> iodata()).
 -type reconnect_sleep() :: no_reconnect | integer().
 -type registered_name() :: {local, atom()} | {global, term()} | {via, atom(), term()}.
 
 -type option() :: {host, string() | {local, string()}} |
                   {port, inet:port_number()} |
                   {database, integer()} |
-                  {username, iodata() | secret() | undefined} |
-                  {password, iodata() | secret() | undefined} |
+                  {username, iodata() | obfuscated() | undefined} |
+                  {password, iodata() | obfuscated() | undefined} |
                   {reconnect_sleep, reconnect_sleep()} |
                   {connect_timeout, integer()} |
                   {socket_options, list()} |

--- a/include/eredis_sub.hrl
+++ b/include/eredis_sub.hrl
@@ -1,34 +1,34 @@
--record(state, {
-                host :: string() | undefined,
-                port :: integer() | undefined,
-                database :: binary() | undefined,
-                auth_cmd :: secret() | undefined,
-                reconnect_sleep :: integer() | undefined | no_reconnect,
-                connect_timeout :: integer() | undefined,
-                socket_options :: list(),
-                tls_options :: list(),
+-record(state,
+        {host :: string() | undefined,
+         port :: integer() | undefined,
+         database :: binary() | undefined,
+         auth_cmd :: secret() | undefined,
+         reconnect_sleep :: integer() | undefined | no_reconnect,
+         connect_timeout :: integer() | undefined,
+         socket_options :: list(),
+         tls_options :: list(),
 
-                transport :: gen_tcp | ssl,
-                socket :: gen_tcp:socket() | ssl:sslsocket() | undefined,
-                reconnect_timer :: reference() | undefined,
-                parser_state :: #pstate{} | undefined,
+         transport :: gen_tcp | ssl,
+         socket :: gen_tcp:socket() | ssl:sslsocket() | undefined,
+         reconnect_timer :: reference() | undefined,
+         parser_state :: #pstate{} | undefined,
 
-                %% Channels we should subscribe to
-                channels = [] :: [channel()],
-                pchannels = [] :: [channel()], % psubscribe
+         %% Channels we should subscribe to
+         channels = [] :: [channel()],
+         pchannels = [] :: [channel()], % psubscribe
 
-                %% The process we send pubsub and connection state messages to.
-                controlling_process :: undefined | {reference(), pid()},
+         %% The process we send pubsub and connection state messages to.
+         controlling_process :: undefined | {reference(), pid()},
 
-                %% This is the queue of messages to send to the controlling process.
-                msg_queue :: eredis_queue(),
+         %% This is the queue of messages to send to the controlling process.
+         msg_queue :: eredis_queue(),
 
-                %% When the queue reaches this size, either drop all
-                %% messages or exit.
-                max_queue_size :: integer() | inifinity,
-                queue_behaviour :: drop | exit,
+         %% When the queue reaches this size, either drop all
+         %% messages or exit.
+         max_queue_size :: integer() | inifinity,
+         queue_behaviour :: drop | exit,
 
-                %% The msg_state keeps track of whether we are waiting for the
-                %% controlling process to acknowledge the last message.
-                msg_state = need_ack :: ready | need_ack
-               }).
+         %% The msg_state keeps track of whether we are waiting for the
+         %% controlling process to acknowledge the last message.
+         msg_state = need_ack :: ready | need_ack
+        }).

--- a/include/eredis_sub.hrl
+++ b/include/eredis_sub.hrl
@@ -1,34 +1,34 @@
 -record(state, {
-          host :: string() | undefined,
-          port :: integer() | undefined,
-          database :: binary() | undefined,
-          auth_cmd :: secret() | undefined,
-          reconnect_sleep :: integer() | undefined | no_reconnect,
-          connect_timeout :: integer() | undefined,
-          socket_options :: list(),
-          tls_options :: list(),
+                host :: string() | undefined,
+                port :: integer() | undefined,
+                database :: binary() | undefined,
+                auth_cmd :: secret() | undefined,
+                reconnect_sleep :: integer() | undefined | no_reconnect,
+                connect_timeout :: integer() | undefined,
+                socket_options :: list(),
+                tls_options :: list(),
 
-          transport :: gen_tcp | ssl,
-          socket :: gen_tcp:socket() | ssl:sslsocket() | undefined,
-          reconnect_timer :: reference() | undefined,
-          parser_state :: #pstate{} | undefined,
+                transport :: gen_tcp | ssl,
+                socket :: gen_tcp:socket() | ssl:sslsocket() | undefined,
+                reconnect_timer :: reference() | undefined,
+                parser_state :: #pstate{} | undefined,
 
-          %% Channels we should subscribe to
-          channels = [] :: [channel()],
-          pchannels = [] :: [channel()], % psubscribe
+                %% Channels we should subscribe to
+                channels = [] :: [channel()],
+                pchannels = [] :: [channel()], % psubscribe
 
-          %% The process we send pubsub and connection state messages to.
-          controlling_process :: undefined | {reference(), pid()},
+                %% The process we send pubsub and connection state messages to.
+                controlling_process :: undefined | {reference(), pid()},
 
-          %% This is the queue of messages to send to the controlling process.
-          msg_queue :: eredis_queue(),
+                %% This is the queue of messages to send to the controlling process.
+                msg_queue :: eredis_queue(),
 
-          %% When the queue reaches this size, either drop all
-          %% messages or exit.
-          max_queue_size :: integer() | inifinity,
-          queue_behaviour :: drop | exit,
+                %% When the queue reaches this size, either drop all
+                %% messages or exit.
+                max_queue_size :: integer() | inifinity,
+                queue_behaviour :: drop | exit,
 
-          %% The msg_state keeps track of whether we are waiting for the
-          %% controlling process to acknowledge the last message.
-          msg_state = need_ack :: ready | need_ack
-}).
+                %% The msg_state keeps track of whether we are waiting for the
+                %% controlling process to acknowledge the last message.
+                msg_state = need_ack :: ready | need_ack
+               }).

--- a/include/eredis_sub.hrl
+++ b/include/eredis_sub.hrl
@@ -2,7 +2,7 @@
         {host :: string() | undefined,
          port :: integer() | undefined,
          database :: binary() | undefined,
-         auth_cmd :: secret() | undefined,
+         auth_cmd :: obfuscated() | undefined,
          reconnect_sleep :: integer() | undefined | no_reconnect,
          connect_timeout :: integer() | undefined,
          socket_options :: list(),

--- a/include/eredis_sub.hrl
+++ b/include/eredis_sub.hrl
@@ -2,7 +2,7 @@
           host :: string() | undefined,
           port :: integer() | undefined,
           database :: binary() | undefined,
-          auth_cmd :: fun(() -> iodata()) | undefined,
+          auth_cmd :: secret() | undefined,
           reconnect_sleep :: integer() | undefined | no_reconnect,
           connect_timeout :: integer() | undefined,
           socket_options :: list(),

--- a/priv/basho_bench_eredis.config
+++ b/priv/basho_bench_eredis.config
@@ -1,5 +1,5 @@
 {mode, max}.
-%{mode, {rate, 5}}.
+%%{mode, {rate, 5}}.
 
 {duration, 15}.
 
@@ -14,4 +14,4 @@
 {key_generator, {uniform_int, 10000}}.
 
 {value_generator, {function, basho_bench_driver_eredis, value_gen, []}}.
-%{value_generator, {fixed_bin, 1}}.
+%%{value_generator, {fixed_bin, 1}}.

--- a/priv/basho_bench_eredis_pipeline.config
+++ b/priv/basho_bench_eredis_pipeline.config
@@ -1,5 +1,5 @@
 {mode, max}.
-%{mode, {rate, 5}}.
+%%{mode, {rate, 5}}.
 
 {duration, 15}.
 
@@ -14,4 +14,4 @@
 {key_generator, {uniform_int, 10000}}.
 
 {value_generator, {function, basho_bench_driver_eredis, value_gen, []}}.
-%{value_generator, {fixed_bin, 1}}.
+%%{value_generator, {fixed_bin, 1}}.

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
            , strict_validation
            , warn_export_vars
            , warn_exported_vars
-        %% , warn_missing_spec
+             %% , warn_missing_spec
            , warn_untyped_record
            , debug_info
            , {platform_define, "^[0-9]+", namespaced_types} % OTP >= 17
@@ -25,10 +25,10 @@
 
 {dialyzer, [{plt_extra_apps, [ssl]},
             {warnings, [
-                       %%   unmatched_returns
+                        %%   unmatched_returns
                         error_handling
-                       %% , underspecs
-                       %% , race_conditions
+                        %% , underspecs
+                        %% , race_conditions
                        ]}]}.
 
 {xref_checks, [ undefined_function_calls

--- a/rebar.config
+++ b/rebar.config
@@ -51,3 +51,5 @@
                         {branch, "master"}}}
                      ]}]
             }]}.
+
+{plugins, [{rebar3_fmt, "1.18.0"}]}.

--- a/src/eredis.app.src
+++ b/src/eredis.app.src
@@ -1,9 +1,9 @@
 {application,eredis,
-             [{description,"Erlang Redis Client"},
-              {vsn,"1.6.0"},
-              {modules,[eredis,eredis_client,eredis_parser,eredis_sub,
-                        eredis_sub_client, eredis_sentinel]},
-              {registered,[]},
-              {applications,[kernel,stdlib]},
-              {maintainers,["Bjorn Svensson", "Viktor Soderqvist"]},
-              {licenses,["MIT"]}]}.
+ [{description,"Erlang Redis Client"},
+  {vsn,"1.6.0"},
+  {modules,[eredis,eredis_client,eredis_parser,eredis_sub,
+            eredis_sub_client, eredis_sentinel]},
+  {registered,[]},
+  {applications,[kernel,stdlib]},
+  {maintainers,["Bjorn Svensson", "Viktor Soderqvist"]},
+  {licenses,["MIT"]}]}.

--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -142,7 +142,7 @@ stop(Client) ->
     eredis_client:stop(Client).
 
 -spec q(Client::client(), Command::[any()]) ->
-               {ok, return_value()} | {error, Reason::binary() | no_connection}.
+          {ok, return_value()} | {error, Reason::binary() | no_connection}.
 %% @doc: Executes the given command in the specified connection. The
 %% command must be a valid Redis command and may contain arbitrary
 %% data which will be converted to binaries. The returned values will
@@ -151,15 +151,15 @@ q(Client, Command) ->
     call(Client, Command, ?TIMEOUT).
 
 -spec q(Client::client(), Command::[any()], Timeout::integer()) ->
-               {ok, return_value()} | {error, Reason::binary() | no_connection}.
+          {ok, return_value()} | {error, Reason::binary() | no_connection}.
 %% @doc Like q/2 with a custom timeout.
 q(Client, Command, Timeout) ->
     call(Client, Command, Timeout).
 
 
 -spec qp(Client::client(), Pipeline::pipeline()) ->
-                [{ok, return_value()} | {error, Reason::binary()}] |
-                {error, no_connection}.
+          [{ok, return_value()} | {error, Reason::binary()}] |
+          {error, no_connection}.
 %% @doc: Executes the given pipeline (list of commands) in the
 %% specified connection. The commands must be valid Redis commands and
 %% may contain arbitrary data which will be converted to binaries. The
@@ -168,8 +168,8 @@ qp(Client, Pipeline) ->
     pipeline(Client, Pipeline, ?TIMEOUT).
 
 -spec qp(Client::client(), Pipeline::pipeline(), Timeout::integer()) ->
-                [{ok, return_value()} | {error, Reason::binary()}] |
-                {error, no_connection}.
+          [{ok, return_value()} | {error, Reason::binary()}] |
+          {error, no_connection}.
 %% @doc Like qp/2 with a custom timeout.
 qp(Client, Pipeline, Timeout) ->
     pipeline(Client, Pipeline, Timeout).
@@ -182,9 +182,9 @@ q_noreply(Client, Command) ->
     cast(Client, Command).
 
 -spec q_async(Client::client(), Command::[any()]) -> ok.
-% @doc Executes the command, and sends a message to the calling process with the
-% response (with either error or success). Message is of the form `{response,
-% Reply}', where `Reply' is the reply expected from `q/2'.
+%% @doc Executes the command, and sends a message to the calling process with the
+%% response (with either error or success). Message is of the form `{response,
+%% Reply}', where `Reply' is the reply expected from `q/2'.
 q_async(Client, Command) ->
     q_async(Client, Command, self()).
 

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -41,7 +41,7 @@
 -record(state, {
                 host            :: string() | {local, string()} | undefined,
                 port            :: integer() | undefined,
-                auth_cmd        :: secret() | undefined,
+                auth_cmd        :: obfuscated() | undefined,
                 database        :: binary() | undefined,
                 reconnect_sleep :: reconnect_sleep() | undefined,
                 connect_timeout :: integer() | undefined,
@@ -410,7 +410,7 @@ connect(#state{host = Host0,
               SocketOptions  :: list(),
               TlsOptions     :: list(),
               ConnectTimeout :: integer() | undefined,
-              AuthCmd        :: secret() | undefined,
+              AuthCmd        :: obfuscated() | undefined,
               Db             :: binary() | undefined) ->
           {ok, Socket :: gen_tcp:socket() | ssl:sslsocket()} |
           {error, Reason :: term()}.
@@ -607,9 +607,9 @@ read_database(undefined) ->
 read_database(Database) when is_integer(Database) ->
     list_to_binary(integer_to_list(Database)).
 
--spec get_auth_command(Username :: iodata() | secret() | undefined,
-                       Password :: iodata() | secret() | undefined) ->
-          secret() | undefined.
+-spec get_auth_command(Username :: iodata() | obfuscated() | undefined,
+                       Password :: iodata() | obfuscated() | undefined) ->
+          obfuscated() | undefined.
 get_auth_command(Username, Password) ->
     case {deobfuscate(Username), deobfuscate(Password)} of
         {undefined, undefined} ->

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -41,7 +41,7 @@
 -record(state, {
                 host            :: string() | {local, string()} | undefined,
                 port            :: integer() | undefined,
-                auth_cmd        :: fun(() -> iodata()) | undefined,
+                auth_cmd        :: secret() | undefined,
                 database        :: binary() | undefined,
                 reconnect_sleep :: reconnect_sleep() | undefined,
                 connect_timeout :: integer() | undefined,
@@ -410,7 +410,7 @@ connect(#state{host = Host0,
               SocketOptions  :: list(),
               TlsOptions     :: list(),
               ConnectTimeout :: integer() | undefined,
-              AuthCmd        :: fun(() -> iodata()) | undefined,
+              AuthCmd        :: secret() | undefined,
               Db             :: binary() | undefined) ->
           {ok, Socket :: gen_tcp:socket() | ssl:sslsocket()} |
           {error, Reason :: term()}.
@@ -607,9 +607,9 @@ read_database(undefined) ->
 read_database(Database) when is_integer(Database) ->
     list_to_binary(integer_to_list(Database)).
 
--spec get_auth_command(Username :: iodata() | fun(() -> iodata()) | undefined,
-                       Password :: iodata() | fun(() -> iodata()) | undefined) ->
-          fun(() -> iodata()) | undefined.
+-spec get_auth_command(Username :: iodata() | secret() | undefined,
+                       Password :: iodata() | secret() | undefined) ->
+          secret() | undefined.
 get_auth_command(Username, Password) ->
     case {deobfuscate(Username), deobfuscate(Password)} of
         {undefined, undefined} ->

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -376,18 +376,18 @@ connect(#state{host = Host0,
                database = Db,
                sentinel = SentinelOptions} = State) ->
     Endpoint = case SentinelOptions of
-                     undefined -> {Host0, Port0};
-                     _ ->
-                         MasterGroup = proplists:get_value(master_group, SentinelOptions, mymaster),
-                         case whereis(MasterGroup) of
-                             undefined -> eredis_sentinel:start_link(MasterGroup, SentinelOptions);
-                             _ -> ok
-                         end,
-                         case eredis_sentinel:get_master(MasterGroup) of
-                             {ok, Host1, Port1} -> {Host1, Port1};
-                             SentinelError -> SentinelError
-                         end
-                 end,
+                   undefined -> {Host0, Port0};
+                   _ ->
+                       MasterGroup = proplists:get_value(master_group, SentinelOptions, mymaster),
+                       case whereis(MasterGroup) of
+                           undefined -> eredis_sentinel:start_link(MasterGroup, SentinelOptions);
+                           _ -> ok
+                       end,
+                       case eredis_sentinel:get_master(MasterGroup) of
+                           {ok, Host1, Port1} -> {Host1, Port1};
+                           SentinelError -> SentinelError
+                       end
+               end,
     case Endpoint of
         {error, _} = Err -> Err;
         {Host, Port} ->

--- a/src/eredis_parser.erl
+++ b/src/eredis_parser.erl
@@ -38,11 +38,11 @@ init() ->
 
 
 -spec parse(State::#pstate{}, Data::binary()) ->
-                   {ok, return_value(), NewState::#pstate{}} |
-                       {ok, return_value(), Rest::binary(), NewState::#pstate{}} |
-                       {error, ErrString::binary(), NewState::#pstate{}} |
-                       {error, ErrString::binary(), Rest::binary(), NewState::#pstate{}} |
-                       {continue, NewState::#pstate{}}.
+          {ok, return_value(), NewState::#pstate{}} |
+          {ok, return_value(), Rest::binary(), NewState::#pstate{}} |
+          {error, ErrString::binary(), NewState::#pstate{}} |
+          {error, ErrString::binary(), Rest::binary(), NewState::#pstate{}} |
+          {continue, NewState::#pstate{}}.
 
 %% @doc: Parses the (possibly partial) response from Redis. Returns
 %% either {ok, Value, NewState}, {ok, Value, Rest, NewState} or
@@ -206,11 +206,11 @@ split_by_newline(Acc, Data) ->
 %% binary:split/2 seems faster than binary:match/2 for this use-case
 binary_split_newline(Data) ->
     Pattern = case get(?NL_KEY) of
-        undefined ->
-            P = binary:compile_pattern(<<?NL>>),
-            put(?NL_KEY, P),
-            P;
-        P ->
-            P
-    end,
+                  undefined ->
+                      P = binary:compile_pattern(<<?NL>>),
+                      put(?NL_KEY, P),
+                      P;
+                  P ->
+                      P
+              end,
     binary:split(Data, Pattern).

--- a/src/eredis_sentinel.erl
+++ b/src/eredis_sentinel.erl
@@ -20,8 +20,8 @@
 -record(eredis_sentinel_state, {
                                 master_group    :: atom(),
                                 endpoints       :: [{string() | {local, string()} , integer()}],
-                                username        :: secret() | undefined,
-                                password        :: secret() | undefined,
+                                username        :: obfuscated() | undefined,
+                                password        :: obfuscated() | undefined,
                                 connect_timeout :: integer() | undefined,
                                 socket_options  :: list(),
                                 tls_options     :: list(),
@@ -243,8 +243,8 @@ get_master_response({error, <<"IDONTKNOW", _Rest/binary >>}) ->
 
 %% Obfuscate a string by wrapping it in a fun that returns the string when
 %% applied. This hides the secrets from stacktraces and logs.
--spec obfuscate(iodata() | secret() | undefined) ->
-          secret() | undefined.
+-spec obfuscate(iodata() | obfuscated() | undefined) ->
+          obfuscated() | undefined.
 obfuscate(undefined) ->
     undefined;
 obfuscate(String) when is_list(String); is_binary(String) ->

--- a/src/eredis_sentinel.erl
+++ b/src/eredis_sentinel.erl
@@ -20,8 +20,8 @@
 -record(eredis_sentinel_state, {
                                 master_group    :: atom(),
                                 endpoints       :: [{string() | {local, string()} , integer()}],
-                                username        :: fun(() -> iodata()) | undefined,
-                                password        :: fun(() -> iodata()) | undefined,
+                                username        :: secret() | undefined,
+                                password        :: secret() | undefined,
                                 connect_timeout :: integer() | undefined,
                                 socket_options  :: list(),
                                 tls_options     :: list(),
@@ -243,8 +243,8 @@ get_master_response({error, <<"IDONTKNOW", _Rest/binary >>}) ->
 
 %% Obfuscate a string by wrapping it in a fun that returns the string when
 %% applied. This hides the secrets from stacktraces and logs.
--spec obfuscate(iodata() | fun(() -> iodata()) | undefined) ->
-          fun(() -> iodata()) | undefined.
+-spec obfuscate(iodata() | secret() | undefined) ->
+          secret() | undefined.
 obfuscate(undefined) ->
     undefined;
 obfuscate(String) when is_list(String); is_binary(String) ->

--- a/src/eredis_sentinel.erl
+++ b/src/eredis_sentinel.erl
@@ -30,7 +30,7 @@
                                }).
 
 -define(CONNECT_TIMEOUT, 5000).
-%́% Sentinel errors
+%% Sentinel errors
 -define(SENTINEL_UNREACHABLE, sentinel_unreachable).
 -define(MASTER_UNKNOWN, master_unknown).
 -define(MASTER_UNREACHABLE, master_unreachable).

--- a/src/eredis_sub_client.erl
+++ b/src/eredis_sub_client.erl
@@ -271,13 +271,13 @@ remove_channels(Channels, OldChannels) ->
 -spec add_channels([binary()], [binary()]) -> [binary()].
 add_channels(Channels, OldChannels) ->
     lists:foldl(fun(C, Cs) ->
-        case lists:member(C, Cs) of
-            true ->
-                Cs;
-            false ->
-                [C|Cs]
-        end
-    end, OldChannels, Channels).
+                        case lists:member(C, Cs) of
+                            true ->
+                                Cs;
+                            false ->
+                                [C|Cs]
+                        end
+                end, OldChannels, Channels).
 
 %% @doc Sends a subscribe or psubscribe command to Redis.
 -spec send_subscribe_command(Transport :: gen_tcp | ssl,

--- a/test/eredis_parser_tests.erl
+++ b/test/eredis_parser_tests.erl
@@ -358,7 +358,7 @@ parse_bulks_with_chunk_split_in_size_test() ->
 %% Helpers
 %%
 
-% parse a binary one byte at a time
+%% parse a binary one byte at a time
 one_byte_parse(B) ->
     one_byte_parse(init(), B).
 

--- a/test/eredis_pubsub_SUITE.erl
+++ b/test/eredis_pubsub_SUITE.erl
@@ -155,17 +155,17 @@ t_dynamic_channels(Config) when is_list(Config) ->
     %% We do the following twice to show that subscribing to the same channel
     %% doesn't cause the channel to show up twice
     lists:foreach(fun(_) ->
-        eredis_sub:subscribe(Sub, [<<"newchan">>, <<"otherchan">>]),
-        receive M1 -> ?assertEqual({subscribed, <<"newchan">>, Sub}, M1) end,
-        eredis_sub:ack_message(Sub),
-        receive M2 -> ?assertEqual({subscribed, <<"otherchan">>, Sub}, M2) end,
-        eredis_sub:ack_message(Sub),
+                          eredis_sub:subscribe(Sub, [<<"newchan">>, <<"otherchan">>]),
+                          receive M1 -> ?assertEqual({subscribed, <<"newchan">>, Sub}, M1) end,
+                          eredis_sub:ack_message(Sub),
+                          receive M2 -> ?assertEqual({subscribed, <<"otherchan">>, Sub}, M2) end,
+                          eredis_sub:ack_message(Sub),
 
-        {ok, Channels} = eredis_sub:channels(Sub),
-        ?assertEqual(true, lists:member(<<"otherchan">>, Channels)),
-        ?assertEqual(true, lists:member(<<"newchan">>, Channels)),
-        ?assertEqual(2, length(Channels))
-    end, lists:seq(0, 1)),
+                          {ok, Channels} = eredis_sub:channels(Sub),
+                          ?assertEqual(true, lists:member(<<"otherchan">>, Channels)),
+                          ?assertEqual(true, lists:member(<<"newchan">>, Channels)),
+                          ?assertEqual(2, length(Channels))
+                  end, lists:seq(0, 1)),
 
     eredis:q(Pub, [publish, newchan, foo]),
     ?assertEqual([{message, <<"newchan">>, <<"foo">>, Sub}], recv_all(Sub)),
@@ -184,7 +184,7 @@ t_dynamic_channels(Config) when is_list(Config) ->
     eredis_sub:ack_message(Sub),
     ?assertEqual({ok, []}, eredis_sub:channels(Sub)).
 
-% Tests for Pattern Subscribe
+%% Tests for Pattern Subscribe
 t_pubsub_pattern(Config) when is_list(Config) ->
     Pub = c(),
     Sub = s(),
@@ -282,7 +282,7 @@ recv_all(Sub, Acc) ->
             eredis_sub:ack_message(Sub),
             recv_all(Sub, [InMsg | Acc])
     after 5 ->
-              lists:reverse(Acc)
+            lists:reverse(Acc)
     end.
 
 subscriber(Client) ->

--- a/test/eredis_sentinel_SUITE.erl
+++ b/test/eredis_sentinel_SUITE.erl
@@ -57,11 +57,11 @@ t_connect_with_mix_sentinel_endpoints(Config) when is_list(Config) ->
 
 t_connect_with_explicit_options(Config) when is_list(Config) ->
     connect_eredis_sentinel([{sentinel, [{master_group, mymaster},
-                                           {endpoints, [{"127.0.0.1", ?SENTINEL_PORT}]},
-                                           {connect_timeout, 5000},
-                                           {socket_options, [{keepalive, true}]},
-                                           {password, ""}
-                                          ]}]).
+                                         {endpoints, [{"127.0.0.1", ?SENTINEL_PORT}]},
+                                         {connect_timeout, 5000},
+                                         {socket_options, [{keepalive, true}]},
+                                         {password, ""}
+                                        ]}]).
 
 t_stop(Config) when is_list(Config) ->
     process_flag(trap_exit, true),


### PR DESCRIPTION
Adds a check in CI to make sure that new code is formatted according to the emacs-mode standard.
The `erlang-formatter` is used and can be run via `rebar3 fmt`.

This adds the missing CI step mentioned in #62