### PR TITLE
Documentation corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ response is returned, Eredis is not blocked.
 
 ## Reconnecting on Redis down / network failure / timeout / etc
 
-When Eredis for some reason looses the connection to Redis, Eredis
+When Eredis for some reason loses the connection to Redis, Eredis
 will keep trying to reconnect until a connection is successfully
 established, which includes the `AUTH` and `SELECT` calls. The sleep
 time between attempts to reconnect can be set in the
@@ -223,7 +223,7 @@ immediately with `{connection_error, Reason}`.
 
 Thanks to Dave Peticolas (jdavisp3), eredis supports
 pubsub. [`eredis_sub`](doc/eredis_sub.md) offers a separate client that will forward
-channel messages from Redis to an Erlang process in a "active-once"
+channel messages from Redis to an Erlang process in an "active-once"
 pattern similar to gen_tcp sockets. After every message received, the
 controlling process must acknowledge receipt using
 `eredis_sub:ack_message/1`.
@@ -335,7 +335,7 @@ data arrives on the socket.
 
 ## Tests and code checking
 
-EUnit tests currently requires a locally running instance of Redis.
+EUnit tests currently require a locally running instance of Redis.
 
 ```console
 rebar3 eunit
@@ -357,7 +357,7 @@ reference counted. This could be improved by replacing it with an
 iolist.
 
 When parsing bulk replies, the parser knows the size of the bulk. If the
-bulk is big and would come in many chunks, this could improved by
+bulk is big and would come in many chunks, this could be improved by
 having the client explicitly use `gen_tcp:recv/2` to fetch the entire
 bulk at once.
 

--- a/doc/eredis.md
+++ b/doc/eredis.md
@@ -53,7 +53,7 @@ obfuscated() = fun(() -&gt; iodata())
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="http://www.erlang.org/doc/man/ssl.html#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
+option() = {host, string() | {local, string()}} | {port, <a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="https://www.erlang.org/doc/man/ssl.html#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
 </code>
 </pre>
 
@@ -383,7 +383,7 @@ Connect with the given options.
 ### start_link/2 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
 </code>
 </pre>
 
@@ -397,7 +397,7 @@ Connect to the given host and port.
 ### start_link/3 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, OptionsOrDatabase) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, OptionsOrDatabase) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
 </code>
 </pre>
 
@@ -410,7 +410,7 @@ __This function is deprecated:__ Use [`start_link/1`](#start_link-1) instead.
 ### start_link/4 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string()) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string()) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 
@@ -424,7 +424,7 @@ __See also:__ [start_link/1](#start_link-1).
 ### start_link/5 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 
@@ -438,7 +438,7 @@ __See also:__ [start_link/1](#start_link-1).
 ### start_link/6 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout()) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout()) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 
@@ -452,7 +452,7 @@ __See also:__ [start_link/1](#start_link-1).
 ### start_link/7 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout(), SocketOptions::list()) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout(), SocketOptions::list()) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 

--- a/doc/eredis.md
+++ b/doc/eredis.md
@@ -53,7 +53,7 @@ obfuscated() = fun(() -&gt; iodata())
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
+option() = {host, string() | {local, string()}} | {port, <a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="http://www.erlang.org/doc/man/ssl.html#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
 </code>
 </pre>
 
@@ -383,7 +383,7 @@ Connect with the given options.
 ### start_link/2 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
 </code>
 </pre>
 
@@ -397,7 +397,7 @@ Connect to the given host and port.
 ### start_link/3 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, OptionsOrDatabase) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, OptionsOrDatabase) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
 </code>
 </pre>
 
@@ -410,7 +410,7 @@ __This function is deprecated:__ Use [`start_link/1`](#start_link-1) instead.
 ### start_link/4 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::integer(), Password::string()) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string()) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 
@@ -424,7 +424,7 @@ __See also:__ [start_link/1](#start_link-1).
 ### start_link/5 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 
@@ -438,7 +438,7 @@ __See also:__ [start_link/1](#start_link-1).
 ### start_link/6 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout()) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout()) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 
@@ -452,7 +452,7 @@ __See also:__ [start_link/1](#start_link-1).
 ### start_link/7 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout(), SocketOptions::list()) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout(), SocketOptions::list()) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 

--- a/doc/eredis.md
+++ b/doc/eredis.md
@@ -305,7 +305,7 @@ start_link(Options::<a href="#type-options">options()</a>) -&gt; {ok, pid()} | {
 <dd>A 0-ary function that returns the password
   (the preferred way to provide password as it prevents the actual secret from
   appearing in logs and stacktraces), a string or iodata or the
-  atom <code>undefined</code> for no username; default <code>undefined</code>
+  atom <code>undefined</code> for no password; default <code>undefined</code>
 </dd>
 
 

--- a/doc/eredis_sub.md
+++ b/doc/eredis_sub.md
@@ -41,7 +41,7 @@ obfuscated() = fun(() -&gt; iodata())
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
+option() = {host, string() | {local, string()}} | {port, <a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="http://www.erlang.org/doc/man/ssl.html#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
 </code>
 </pre>
 

--- a/doc/eredis_sub.md
+++ b/doc/eredis_sub.md
@@ -41,7 +41,7 @@ obfuscated() = fun(() -&gt; iodata())
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="http://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="http://www.erlang.org/doc/man/ssl.html#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
+option() = {host, string() | {local, string()}} | {port, <a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="https://www.erlang.org/doc/man/ssl.html#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
 </code>
 </pre>
 

--- a/rebar.config
+++ b/rebar.config
@@ -38,11 +38,9 @@
               ]}.
 
 {edoc_opts, [ {doclet, edown_doclet}
-            , {dialyzer_specs, all}
-            , {report_missing_type, true}
-            , {report_type_mismatch, true}
-            , {pretty_print, erl_pp}
+            , {report_missing_types, true}
             , {preprocess, true}
+            , {app_default, "http://www.erlang.org/doc/man"} % https not handled correctly
             ]}.
 
 {profiles, [{docs, [{deps,

--- a/rebar.config
+++ b/rebar.config
@@ -40,7 +40,7 @@
 {edoc_opts, [ {doclet, edown_doclet}
             , {report_missing_types, true}
             , {preprocess, true}
-            , {app_default, "http://www.erlang.org/doc/man"} % https not handled correctly
+            , {app_default, "https://www.erlang.org/doc/man"}
             ]}.
 
 {profiles, [{docs, [{deps,

--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -55,7 +55,7 @@ start_link() ->
 %% <dt>`{password, Password}'</dt><dd>A 0-ary function that returns the password
 %% (the preferred way to provide password as it prevents the actual secret from
 %% appearing in logs and stacktraces), a string or iodata or the
-%% atom `undefined' for no username; default `undefined'</dd>
+%% atom `undefined' for no password; default `undefined'</dd>
 %% <dt>`{reconnect_sleep, ReconnectSleep}'</dt><dd>Integer of milliseconds to
 %% sleep between reconnect attempts; default: 100</dd>
 %% <dt>`{connect_timeout, Timeout}'</dt><dd>Timeout value in milliseconds to use


### PR DESCRIPTION
Fix some spelling errors. 

The PR includes `edoc` and `edown` configuration updates in rebar.config which
- adds working links to Erlang types.
- corrects the edoc config `report_missing_types`.
- removes configs used by the standard HTML layout module.
