### PR TITLE
Dialyzer: Fix eredis:q/3, eredis:qp/3 type specs

### DIFF
--- a/doc/eredis.md
+++ b/doc/eredis.md
@@ -154,7 +154,7 @@ always be binaries.
 ### q/3 ###
 
 <pre><code>
-q(Client::<a href="#type-client">client()</a>, Command::[any()], Timeout::integer()) -&gt; {ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::binary() | no_connection}
+q(Client::<a href="#type-client">client()</a>, Command::[any()], Timeout::timeout()) -&gt; {ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::binary() | no_connection}
 </code>
 </pre>
 
@@ -225,7 +225,7 @@ values returned by each command in the pipeline are returned in a list.
 ### qp/3 ###
 
 <pre><code>
-qp(Client::<a href="#type-client">client()</a>, Pipeline::<a href="#type-pipeline">pipeline()</a>, Timeout::integer()) -&gt; [{ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::binary()}] | {error, no_connection}
+qp(Client::<a href="#type-client">client()</a>, Pipeline::<a href="#type-pipeline">pipeline()</a>, Timeout::timeout()) -&gt; [{ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::binary()}] | {error, no_connection}
 </code>
 </pre>
 

--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -150,7 +150,7 @@ stop(Client) ->
 q(Client, Command) ->
     call(Client, Command, ?TIMEOUT).
 
--spec q(Client::client(), Command::[any()], Timeout::integer()) ->
+-spec q(Client::client(), Command::[any()], Timeout::timeout()) ->
           {ok, return_value()} | {error, Reason::binary() | no_connection}.
 %% @doc Like q/2 with a custom timeout.
 q(Client, Command, Timeout) ->
@@ -167,7 +167,7 @@ q(Client, Command, Timeout) ->
 qp(Client, Pipeline) ->
     pipeline(Client, Pipeline, ?TIMEOUT).
 
--spec qp(Client::client(), Pipeline::pipeline(), Timeout::integer()) ->
+-spec qp(Client::client(), Pipeline::pipeline(), Timeout::timeout()) ->
           [{ok, return_value()} | {error, Reason::binary()}] |
           {error, no_connection}.
 %% @doc Like qp/2 with a custom timeout.


### PR DESCRIPTION
Problem.

Timeout in functions eredis:q/3 eredis:qp/3, currently typed as integer() will cause dialyzer error when a client passes infinity as timeout. 

Remedy.

The timeout should have the same type as that of gen_server calls. 


