### PR TITLE
Removed usage of eunit from `eredis_parser.erl`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           sudo dpkg --install $DEB_NAME
 
       - name: Install compatible rebar3 version
-        if: ${{ startsWith(matrix.otp-version, '20.') || startsWith(matrix.otp-version, '21.') || startsWith(matrix.otp-version, '22.')}}
+        if: ${{ startsWith(matrix.otp-version, '20.') || startsWith(matrix.otp-version, '21.') || startsWith(matrix.otp-version, '22.') || startsWith(matrix.otp-version, '23.') || startsWith(matrix.otp-version, '24.')}}
         run: |
           git clone https://github.com/erlang/rebar3.git
           cd rebar3 && git checkout 3.15.2 && ./bootstrap && ./rebar3 local install

--- a/.github/workflows/redis_compability.yml
+++ b/.github/workflows/redis_compability.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install Erlang/OTP
         run: |
-          DEB_NAME="esl-erlang_23.1-1~ubuntu~focal_amd64.deb"
+          DEB_NAME="esl-erlang_25.0.3-1~ubuntu~focal_amd64.deb"
           curl -f https://packages.erlang-solutions.com/erlang/debian/pool/$DEB_NAME -o $DEB_NAME
           sudo dpkg --install $DEB_NAME
 

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Eredis.Mixfile do
     [
       # Use latest version of ex_doc to create correct tables
       # {:ex_doc, "~> 0.22", only: :dev, runtime: false}
-      {:ex_doc, git: "https://github.com/elixir-lang/ex_doc.git", tag: "master", only: :dev, runtime: false}
+      {:ex_doc, git: "https://github.com/elixir-lang/ex_doc.git", tag: "main", only: :dev, runtime: false}
     ]
   end
 

--- a/src/eredis_parser.erl
+++ b/src/eredis_parser.erl
@@ -22,7 +22,6 @@
 %% @private
 -module(eredis_parser).
 -include("eredis.hrl").
--include_lib("eunit/include/eunit.hrl").
 
 -compile({inline, [binary_split_newline/1]}).
 


### PR DESCRIPTION
This is causing compile time issues in Elixir 1.15.0. Seems like eunit isn't being used in this file so I removed it.

Fixes #79