### PR TITLE
Fix type spec

### DIFF
--- a/doc/eredis.md
+++ b/doc/eredis.md
@@ -53,7 +53,7 @@ obfuscated() = fun(() -&gt; iodata())
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
+option() = {host, string() | {local, string()}} | {port, <a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="https://www.erlang.org/doc/man/ssl.html#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
 </code>
 </pre>
 
@@ -383,7 +383,7 @@ Connect with the given options.
 ### start_link/2 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
 </code>
 </pre>
 
@@ -397,7 +397,7 @@ Connect to the given host and port.
 ### start_link/3 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, OptionsOrDatabase) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, OptionsOrDatabase) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
 </code>
 </pre>
 
@@ -410,7 +410,7 @@ __This function is deprecated:__ Use [`start_link/1`](#start_link-1) instead.
 ### start_link/4 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::integer(), Password::string()) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string()) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 
@@ -424,7 +424,7 @@ __See also:__ [start_link/1](#start_link-1).
 ### start_link/5 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 
@@ -438,7 +438,7 @@ __See also:__ [start_link/1](#start_link-1).
 ### start_link/6 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout()) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout()) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 
@@ -452,7 +452,7 @@ __See also:__ [start_link/1](#start_link-1).
 ### start_link/7 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout(), SocketOptions::list()) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout(), SocketOptions::list()) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 

--- a/doc/eredis.md
+++ b/doc/eredis.md
@@ -53,7 +53,7 @@ obfuscated() = fun(() -&gt; iodata())
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="https://www.erlang.org/doc/man/ssl.html#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
+option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
 </code>
 </pre>
 
@@ -113,7 +113,7 @@ registered_name() = {local, atom()} | {global, term()} | {via, atom(), term()}
 
 
 <pre><code>
-return_value() = undefined | binary() | [binary() | nonempty_list()]
+return_value() = undefined | binary() | [binary() | list() | undefined]
 </code>
 </pre>
 
@@ -139,7 +139,7 @@ specified connection.</td></tr><tr><td valign="top"><a href="#qp-3">qp/3</a></td
 ### q/2 ###
 
 <pre><code>
-q(Client::<a href="#type-client">client()</a>, Command::[any()]) -&gt; {ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::binary() | no_connection}
+q(Client::<a href="#type-client">client()</a>, Command::[any()]) -&gt; {ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::any() | no_connection}
 </code>
 </pre>
 
@@ -154,7 +154,7 @@ always be binaries.
 ### q/3 ###
 
 <pre><code>
-q(Client::<a href="#type-client">client()</a>, Command::[any()], Timeout::timeout()) -&gt; {ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::binary() | no_connection}
+q(Client::<a href="#type-client">client()</a>, Command::[any()], Timeout::timeout()) -&gt; {ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::any() | no_connection}
 </code>
 </pre>
 
@@ -210,7 +210,7 @@ __See also:__ [q/2](#q-2).
 ### qp/2 ###
 
 <pre><code>
-qp(Client::<a href="#type-client">client()</a>, Pipeline::<a href="#type-pipeline">pipeline()</a>) -&gt; [{ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::binary()}] | {error, no_connection}
+qp(Client::<a href="#type-client">client()</a>, Pipeline::<a href="#type-pipeline">pipeline()</a>) -&gt; [{ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::any() | no_connection}]
 </code>
 </pre>
 
@@ -225,7 +225,7 @@ values returned by each command in the pipeline are returned in a list.
 ### qp/3 ###
 
 <pre><code>
-qp(Client::<a href="#type-client">client()</a>, Pipeline::<a href="#type-pipeline">pipeline()</a>, Timeout::timeout()) -&gt; [{ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::binary()}] | {error, no_connection}
+qp(Client::<a href="#type-client">client()</a>, Pipeline::<a href="#type-pipeline">pipeline()</a>, Timeout::timeout()) -&gt; [{ok, <a href="#type-return_value">return_value()</a>} | {error, Reason::any() | no_connection}]
 </code>
 </pre>
 
@@ -383,7 +383,7 @@ Connect with the given options.
 ### start_link/2 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
 </code>
 </pre>
 
@@ -397,7 +397,7 @@ Connect to the given host and port.
 ### start_link/3 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, OptionsOrDatabase) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, OptionsOrDatabase) -&gt; {ok, Pid::pid()} | {error, Reason::term()}
 </code>
 </pre>
 
@@ -410,7 +410,7 @@ __This function is deprecated:__ Use [`start_link/1`](#start_link-1) instead.
 ### start_link/4 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string()) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::integer(), Password::string()) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 
@@ -424,7 +424,7 @@ __See also:__ [start_link/1](#start_link-1).
 ### start_link/5 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 
@@ -438,7 +438,7 @@ __See also:__ [start_link/1](#start_link-1).
 ### start_link/6 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout()) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout()) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 
@@ -452,7 +452,7 @@ __See also:__ [start_link/1](#start_link-1).
 ### start_link/7 ###
 
 <pre><code>
-start_link(Host::<a href="#type-host">host()</a>, Port::<a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout(), SocketOptions::list()) -&gt; {ok, pid()} | {error, term()}
+start_link(Host::<a href="#type-host">host()</a>, Port::<a href="inet.md#type-port_number">inet:port_number()</a>, Database::integer(), Password::string(), ReconnectSleep::<a href="#type-reconnect_sleep">reconnect_sleep()</a>, ConnectTimeout::timeout(), SocketOptions::list()) -&gt; {ok, pid()} | {error, term()}
 </code>
 </pre>
 

--- a/doc/eredis_sub.md
+++ b/doc/eredis_sub.md
@@ -41,7 +41,7 @@ obfuscated() = fun(() -&gt; iodata())
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
+option() = {host, string() | {local, string()}} | {port, <a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="https://www.erlang.org/doc/man/ssl.html#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
 </code>
 </pre>
 

--- a/doc/eredis_sub.md
+++ b/doc/eredis_sub.md
@@ -41,7 +41,7 @@ obfuscated() = fun(() -&gt; iodata())
 
 
 <pre><code>
-option() = {host, string() | {local, string()}} | {port, <a href="https://www.erlang.org/doc/man/inet.html#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="https://www.erlang.org/doc/man/ssl.html#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
+option() = {host, string() | {local, string()}} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {database, integer()} | {username, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {password, iodata() | <a href="#type-obfuscated">obfuscated()</a> | undefined} | {reconnect_sleep, <a href="#type-reconnect_sleep">reconnect_sleep()</a>} | {connect_timeout, integer()} | {socket_options, list()} | {tls, [<a href="ssl.md#type-tls_client_option">ssl:tls_client_option()</a>]} | {name, <a href="#type-registered_name">registered_name()</a>} | {sentinel, list()}
 </code>
 </pre>
 

--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -19,7 +19,7 @@
 -type options() :: [option()].
 -type server_args() :: options().               % for backwards compatibility
 
--type return_value() :: undefined | binary() | [binary() | nonempty_list() | undefined].
+-type return_value() :: undefined | binary() | [binary() | list() | undefined].
 
 -type pipeline() :: [iolist()].
 


### PR DESCRIPTION
The `eredis:q/2` function can return a list of empty lists when executing a `MULTI` command.

Minimal example to reproduce:

```
> {ok, Client} = eredis:start_link(localhost, 6379, 0, "redis-password").
{ok,<0.2978.0>}
> eredis:q(Client, ["MULTI"]).
{ok,<<"OK">>}
> eredis:q(Client, ["ZRANGE", <<"non-existent-key">>, 0, 0]).
{ok,<<"QUEUED">>}
> eredis:q(Client, ["ZRANGE", <<"non-existent-key">>, -1, -1]).
{ok,<<"QUEUED">>}
> eredis:q(Client, ["EXEC"]).
{ok,[[],[]]}
```